### PR TITLE
Implement bso/bsolr/bns/bnslr instructions

### DIFF
--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -184,6 +184,12 @@ bool build_bgtlr(BuilderContext& ctx);
 bool build_ble(BuilderContext& ctx);
 bool build_blelr(BuilderContext& ctx);
 
+// Conditional branch (so - summary overflow / unordered)
+bool build_bso(BuilderContext& ctx);
+bool build_bsolr(BuilderContext& ctx);
+bool build_bns(BuilderContext& ctx);
+bool build_bnslr(BuilderContext& ctx);
+
 //=============================================================================
 // Floating Point Builders
 //=============================================================================

--- a/src/codegen/builders/control_flow.cpp
+++ b/src/codegen/builders/control_flow.cpp
@@ -316,4 +316,32 @@ bool build_blelr(BuilderContext& ctx)
     return true;
 }
 
+//=============================================================================
+// Conditional Branch (so - summary overflow / unordered)
+//=============================================================================
+
+bool build_bso(BuilderContext& ctx)
+{
+    ctx.emit_conditional_branch(false, "so");
+    return true;
+}
+
+bool build_bsolr(BuilderContext& ctx)
+{
+    ctx.println("\tif ({}.so) return;", ctx.cr(ctx.insn.operands[0]));
+    return true;
+}
+
+bool build_bns(BuilderContext& ctx)
+{
+    ctx.emit_conditional_branch(true, "so");
+    return true;
+}
+
+bool build_bnslr(BuilderContext& ctx)
+{
+    ctx.println("\tif (!{}.so) return;", ctx.cr(ctx.insn.operands[0]));
+    return true;
+}
+
 } // namespace rexglue::codegen::builders

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -136,6 +136,10 @@ static const std::unordered_map<int, Builder>& GetDispatchTable()
         { PPC_INST_BGTLR, build_bgtlr },
         { PPC_INST_BLE, build_ble },
         { PPC_INST_BLELR, build_blelr },
+        { PPC_INST_BSO, build_bso },
+        { PPC_INST_BSOLR, build_bsolr },
+        { PPC_INST_BNS, build_bns },
+        { PPC_INST_BNSLR, build_bnslr },
 
         //=====================================================================
         // Floating Point


### PR DESCRIPTION
This adds codegen support for these formerly unimplemented Summary Overflow conditional branch instructions:

- bso - branch if SO bit set
- bsolr - branch to link register if SO bit set
- bns - branch if SO bit not set
- bnslr - branch to link register if SO bit not set

I encountered a ton of "Unimplemented instruction" warnings during codegen of the Perfect Dark Zero executable, as there are 1707 instances of them (1,696 bso + 11 bsolr) all together in the binary. 

What's changed:
- src/codegen/builders.h - declarations for build_bso, build_bsolr, build_bns, build_bnslr
- src/codegen/builders/control_flow.cpp - added the implementations using the existing emit_conditional_branch helper and "so" condition string (already supported by crBitName())
- src/codegen/instruction_dispatch.cpp - Added dispatch entries mapping PPC_INST_BSO, PPC_INST_BSOLR, PPC_INST_BNS, PPC_INST_BNSLR to their builders

This implementation follows the same pattern as the already implemented beq/bne/blt/ble/bge families. This is a straightforward change overall.