### PR TITLE
fix: filesystem incorrectly read/writes, rewrite POSIX memory backend to enable rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,5 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+.vscode/

--- a/src/core/filesystem_posix.cpp
+++ b/src/core/filesystem_posix.cpp
@@ -144,14 +144,22 @@ class PosixFileHandle : public FileHandle {
   bool Read(size_t file_offset, void* buffer, size_t buffer_length,
             size_t* out_bytes_read) override {
     ssize_t out = pread(handle_, buffer, buffer_length, file_offset);
-    *out_bytes_read = out;
-    return out >= 0 ? true : false;
+    if (out < 0) {
+        if (out_bytes_read) *out_bytes_read = 0;
+        return false;
+    }
+    if (out_bytes_read) *out_bytes_read = static_cast<size_t>(out);
+    return true;
   }
   bool Write(size_t file_offset, const void* buffer, size_t buffer_length,
              size_t* out_bytes_written) override {
     ssize_t out = pwrite(handle_, buffer, buffer_length, file_offset);
-    *out_bytes_written = out;
-    return out >= 0 ? true : false;
+    if (out < 0) {
+        if (out_bytes_written) *out_bytes_written = 0;
+        return false;
+    }
+    if (out_bytes_written) *out_bytes_written = static_cast<size_t>(out);
+    return true;
   }
   bool SetLength(size_t length) override {
     return ftruncate(handle_, length) >= 0 ? true : false;
@@ -196,18 +204,23 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
 
 bool GetInfo(const std::filesystem::path& path, FileInfo* out_info) {
   struct stat st;
-  if (stat(path.c_str(), &st) == 0) {
-    if (S_ISDIR(st.st_mode)) {
-      out_info->type = FileInfo::Type::kDirectory;
-    } else {
-      out_info->type = FileInfo::Type::kFile;
-    }
-    out_info->create_timestamp = convertUnixtimeToWinFiletime(st.st_ctime);
-    out_info->access_timestamp = convertUnixtimeToWinFiletime(st.st_atime);
-    out_info->write_timestamp = convertUnixtimeToWinFiletime(st.st_mtime);
-    return true;
+  if (stat(path.c_str(), &st) != 0) return false;
+
+  // If FileInfo is POD-ish, you can clear it to avoid future landmines.
+  // *out_info = FileInfo{};
+  // (Only do this if it won't wipe fields the caller expects preserved.)
+
+  if (S_ISDIR(st.st_mode)) {
+    out_info->type = FileInfo::Type::kDirectory;
+    out_info->total_size = 0;
+  } else {
+    out_info->type = FileInfo::Type::kFile;
+    out_info->total_size = static_cast<uint64_t>(st.st_size);
   }
-  return false;
+  out_info->create_timestamp = convertUnixtimeToWinFiletime(st.st_ctime);
+  out_info->access_timestamp = convertUnixtimeToWinFiletime(st.st_atime);
+  out_info->write_timestamp  = convertUnixtimeToWinFiletime(st.st_mtime);
+    return true;
 }
 
 std::vector<FileInfo> ListFiles(const std::filesystem::path& path) {

--- a/src/core/memory_posix.cpp
+++ b/src/core/memory_posix.cpp
@@ -9,28 +9,66 @@
  * @modified    Tom Clay, 2026 - Adapted for ReXGlue runtime
  */
 
+// TODO: Consider splitting this file into multiple files for better organization.
+// memory_posix.cpp - core apis for memory management on POSIX systems.
+// memory_posix_mapped.cpp - mapped memory implementation on POSIX systems.
+// posible split of Linux and Android specific code into their own files.
+
 #include <rex/memory/utils.h>
 
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <cstddef>
 
-#include <rex/math.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+
 #include <rex/platform.h>
 #include <rex/string.h>
+
+#if REX_PLATFORM_LINUX
+#include <fstream>
+#include <string>
+#include <vector>
+#endif
 
 #if REX_PLATFORM_ANDROID
 #include <dlfcn.h>
 #include <linux/ashmem.h>
-#include <string.h>
 #include <sys/ioctl.h>
 
-#include "xenia/base/main_android.h"
+//TODO #include <xenia/base/main_android.h>
 #endif
 
 namespace rex {
 namespace memory {
+
+namespace {
+
+static inline int PosixFixedFlagsFor(void* base_address) {
+  if (!base_address) return 0;
+#if defined(MAP_FIXED_NOREPLACE)
+  return MAP_FIXED_NOREPLACE;
+#else
+  return MAP_FIXED;
+#endif
+}
+
+static inline bool CheckedAdd(uintptr_t a, uintptr_t b, uintptr_t& out) {
+#if defined(__has_builtin)
+#  if __has_builtin(__builtin_add_overflow)
+  return !__builtin_add_overflow(a, b, &out);
+#  endif
+#endif
+  out = a + b;
+  return out >= a;
+}
+
+}  // namespace
 
 #if REX_PLATFORM_ANDROID
 // May be null if no dynamically loaded functions are required.
@@ -60,7 +98,7 @@ void AndroidShutdown() {
 }
 #endif
 
-size_t page_size() { return getpagesize(); }
+size_t page_size() { return static_cast<size_t>(getpagesize()); }
 size_t allocation_granularity() { return page_size(); }
 
 uint32_t ToPosixProtectFlags(PageAccess access) {
@@ -83,40 +121,386 @@ uint32_t ToPosixProtectFlags(PageAccess access) {
 
 bool IsWritableExecutableMemorySupported() { return true; }
 
+#if REX_PLATFORM_LINUX
+namespace {
+
+// ============================================================================
+// Linux-only helpers
+// ============================================================================
+
+struct LinuxMapEntry {
+  uintptr_t start = 0;
+  uintptr_t end = 0;
+  uintptr_t offset = 0;
+  char perms[5] = {};  // "rw-p"
+  uint32_t dev_major = 0;
+  uint32_t dev_minor = 0;
+  uint64_t inode = 0;
+  std::string pathname;
+};
+
+static bool ParseProcMapsLine(const std::string& line, LinuxMapEntry& out) {
+  out = LinuxMapEntry{};
+
+  unsigned long long start = 0, end = 0, offset = 0;
+  unsigned int maj = 0, min = 0;
+  unsigned long inode = 0;
+  char perms[5] = {};
+  int nconsumed = 0;
+
+  const int matched =
+      std::sscanf(line.c_str(), "%llx-%llx %4s %llx %x:%x %lu %n", &start, &end,
+                  perms, &offset, &maj, &min, &inode, &nconsumed);
+  if (matched < 7) return false;
+
+  out.start = static_cast<uintptr_t>(start);
+  out.end = static_cast<uintptr_t>(end);
+  out.offset = static_cast<uintptr_t>(offset);
+  std::memcpy(out.perms, perms, sizeof(out.perms));
+  out.dev_major = static_cast<uint32_t>(maj);
+  out.dev_minor = static_cast<uint32_t>(min);
+  out.inode = static_cast<uint64_t>(inode);
+
+  if (nconsumed > 0 && static_cast<size_t>(nconsumed) < line.size()) {
+    size_t pos = static_cast<size_t>(nconsumed);
+    while (pos < line.size() && line[pos] == ' ') ++pos;
+    if (pos < line.size()) out.pathname = line.substr(pos);
+  }
+
+  return out.start < out.end;
+}
+
+template <typename Fn>
+static bool ForEachProcMapsEntry(Fn&& fn) {
+  std::ifstream maps("/proc/self/maps");
+  if (!maps.is_open()) return false;
+
+  std::string line;
+  LinuxMapEntry e;
+  while (std::getline(maps, line)) {
+    if (!ParseProcMapsLine(line, e)) continue;
+    if (!fn(e)) break;  // false => stop early
+  }
+  return true;
+}
+
+static bool ReadProcMaps(std::vector<LinuxMapEntry>& out_entries) {
+  out_entries.clear();
+  if (!ForEachProcMapsEntry([&](const LinuxMapEntry& e) {
+        out_entries.push_back(e);
+        return true;
+      })) {
+    return false;
+  }
+  return !out_entries.empty();
+}
+
+static bool SameBackingIgnoringPerms(const LinuxMapEntry& a,
+                                     const LinuxMapEntry& b) {
+  const bool a_private = (a.perms[3] == 'p');
+  const bool b_private = (b.perms[3] == 'p');
+
+  // Pathnames can be missing; only compare if both present.
+  const bool both_have_path = !a.pathname.empty() && !b.pathname.empty();
+  const bool path_ok = !both_have_path || (a.pathname == b.pathname);
+
+  return a_private == b_private && a.dev_major == b.dev_major &&
+         a.dev_minor == b.dev_minor && a.inode == b.inode &&
+         a.offset == b.offset && path_ok;
+}
+
+static bool FindEntryForAddressLinux(void* address, LinuxMapEntry& out_entry) {
+  const uintptr_t addr = reinterpret_cast<uintptr_t>(address);
+  bool found = false;
+
+  const bool ok = ForEachProcMapsEntry([&](const LinuxMapEntry& e) {
+    if (addr >= e.start && addr < e.end) {
+      out_entry = e;
+      found = true;
+      return false;
+    }
+    return true;
+  });
+
+  return ok && found;
+}
+
+static bool GetContiguousSpanLinux(void* address, uintptr_t& out_start,
+                                   uintptr_t& out_end) {
+  out_start = 0;
+  out_end = 0;
+
+  std::vector<LinuxMapEntry> entries;
+  if (!ReadProcMaps(entries)) return false;
+
+  const uintptr_t addr = reinterpret_cast<uintptr_t>(address);
+
+  int idx = -1;
+  for (int i = 0; i < static_cast<int>(entries.size()); ++i) {
+    if (addr >= entries[i].start && addr < entries[i].end) {
+      idx = i;
+      break;
+    }
+  }
+  if (idx < 0) return false;
+
+  const LinuxMapEntry& key = entries[idx];
+  uintptr_t start = key.start;
+  uintptr_t end = key.end;
+
+  for (int i = idx - 1; i >= 0; --i) {
+    if (entries[i].end != start) break;
+    if (!SameBackingIgnoringPerms(entries[i], key)) break;
+    start = entries[i].start;
+  }
+
+  for (int i = idx + 1; i < static_cast<int>(entries.size()); ++i) {
+    if (entries[i].start != end) break;
+    if (!SameBackingIgnoringPerms(entries[i], key)) break;
+    end = entries[i].end;
+  }
+
+  out_start = start;
+  out_end = end;
+  return out_start < out_end;
+}
+
+static bool IsRangeFullyMappedLinux(void* base_address, size_t length) {
+  if (!base_address || length == 0) return false;
+
+  const uintptr_t begin = reinterpret_cast<uintptr_t>(base_address);
+  uintptr_t end = 0;
+  if (!CheckedAdd(begin, static_cast<uintptr_t>(length), end)) return false;
+
+  // Ensure [begin,end) has no gaps.
+  uintptr_t cursor = begin;
+  bool had_any = false;
+
+  if (!ForEachProcMapsEntry([&](const LinuxMapEntry& e) {
+        if (e.end <= cursor) return true;
+        had_any = true;
+        if (e.start > cursor) return false;  // gap
+        cursor = e.end;
+        return cursor < end;
+      })) {
+    return false;
+  }
+
+  return had_any && cursor >= end;
+}
+
+// Arena guard (Linux-only)
+static inline uintptr_t HighestPow2LE(uintptr_t x) {
+  if (!x) return 0;
+  const unsigned int msb =
+      63u - static_cast<unsigned int>(
+                __builtin_clzll(static_cast<unsigned long long>(x)));
+  return uintptr_t(1) << msb;
+}
+
+static bool IsRexManagedArenaAddressLinux(void* base_address, size_t length) {
+  if (!base_address || length == 0) return false;
+
+  constexpr uintptr_t kMinMappingBase = 0x100000000ULL;
+  constexpr uintptr_t kTotalSpan = 0x120000000ULL;
+
+  const uintptr_t addr = reinterpret_cast<uintptr_t>(base_address);
+  if (addr < kMinMappingBase) return false;
+
+  uintptr_t end = 0;
+  if (!CheckedAdd(addr, static_cast<uintptr_t>(length), end)) return false;
+
+  const uintptr_t mapping_base = HighestPow2LE(addr);
+  if (mapping_base < kMinMappingBase) return false;
+
+  uintptr_t span_end = 0;
+  if (!CheckedAdd(mapping_base, kTotalSpan, span_end)) return false;
+
+  return addr >= mapping_base && end <= span_end;
+}
+
+static inline void* SanitizeFixedBaseLinux(void* base_address, size_t length) {
+  return (base_address && !IsRexManagedArenaAddressLinux(base_address, length))
+             ? nullptr
+             : base_address;
+}
+
+}  // namespace
+#endif  // REX_PLATFORM_LINUX
+
 void* AllocFixed(void* base_address, size_t length,
                  AllocationType allocation_type, PageAccess access) {
-  // mmap does not support reserve / commit, so ignore allocation_type.
-  uint32_t prot = ToPosixProtectFlags(access);
-  // VERBOSE LOGGING - log mmap calls for heap region (adjust offset as needed)
-  // The actual host address depends on memory layout - log all calls for now
-  fprintf(stderr, "[MMAP] AllocFixed: base=%p len=0x%zx alloc_type=%d prot=0x%x\n",
-          base_address, length, static_cast<int>(allocation_type), prot);
+  const uint32_t prot_requested = ToPosixProtectFlags(access);
 
-  void* result = mmap(base_address, length, prot,
-                      MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS, -1, 0);
-  if (result == MAP_FAILED) {
-    return nullptr;
-  } else {
+  int prot_initial = 0;
+  switch (allocation_type) {
+    case AllocationType::kReserve:
+      prot_initial = PROT_NONE;
+      break;
+    case AllocationType::kCommit:
+    case AllocationType::kReserveCommit:
+    default:
+      prot_initial = static_cast<int>(prot_requested);
+      break;
+  }
+
+  int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+  flags |= PosixFixedFlagsFor(base_address);
+
+  void* result = mmap(base_address, length, prot_initial, flags, -1, 0);
+  if (result != MAP_FAILED) {
     return result;
   }
+
+#if defined(MAP_FIXED_NOREPLACE) && REX_PLATFORM_LINUX
+  // Emulate commit-on-reserve when MAP_FIXED_NOREPLACE hits EEXIST:
+  // 1) If already mapped with no gaps, just mprotect.
+  // 2) Else, only "repair" via MAP_FIXED if inside our arena.
+  if (errno == EEXIST && base_address &&
+      (allocation_type == AllocationType::kCommit ||
+       allocation_type == AllocationType::kReserveCommit)) {
+    if (IsRangeFullyMappedLinux(base_address, length)) {
+      if (mprotect(base_address, length, static_cast<int>(prot_requested)) == 0) {
+        return base_address;
+      }
+      return nullptr;
+    }
+
+    if (IsRexManagedArenaAddressLinux(base_address, length)) {
+      const int repair_flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED;
+      void* repaired =
+          mmap(base_address, length, static_cast<int>(prot_requested),
+               repair_flags, -1, 0);
+      return repaired == MAP_FAILED ? nullptr : repaired;
+    }
+  }
+#endif
+
+  return nullptr;
 }
 
 bool DeallocFixed(void* base_address, size_t length,
                   DeallocationType deallocation_type) {
-  return munmap(base_address, length) == 0;
+  switch (deallocation_type) {
+    case DeallocationType::kDecommit: {
+      if (mprotect(base_address, length, PROT_NONE) != 0) {
+        return false;
+      }
+#if defined(MADV_DONTNEED)
+      (void)madvise(base_address, length, MADV_DONTNEED);
+#endif
+      return true;
+    }
+
+    case DeallocationType::kRelease: {
+      size_t unmap_len = length;
+
+#if REX_PLATFORM_LINUX
+      if (unmap_len == 0) {
+        uintptr_t span_start = 0, span_end = 0;
+        if (!GetContiguousSpanLinux(base_address, span_start, span_end)) {
+          return false;
+        }
+        if (span_start != reinterpret_cast<uintptr_t>(base_address)) {
+          return false;
+        }
+        unmap_len = static_cast<size_t>(span_end - span_start);
+      }
+#else
+      if (unmap_len == 0) {
+        return false;
+      }
+#endif
+
+      return munmap(base_address, unmap_len) == 0;
+    }
+
+    default:
+      return false;
+  }
 }
 
 bool Protect(void* base_address, size_t length, PageAccess access,
              PageAccess* out_old_access) {
-  // Linux does not have a syscall to query memory permissions.
-  assert_null(out_old_access);
+  if (!base_address || length == 0) {
+    if (out_old_access) *out_old_access = PageAccess::kNoAccess;
+    return false;
+  }
 
-  uint32_t prot = ToPosixProtectFlags(access);
-  return mprotect(base_address, length, prot) == 0;
+  if (out_old_access) {
+    size_t ignored_len = 0;
+    PageAccess old_access = PageAccess::kNoAccess;
+    if (!QueryProtect(base_address, ignored_len, old_access)) {
+      *out_old_access = PageAccess::kNoAccess;
+      return false;
+    }
+    *out_old_access = old_access;
+  }
+
+  const uint32_t prot = ToPosixProtectFlags(access);
+  return mprotect(base_address, length, static_cast<int>(prot)) == 0;
 }
 
 bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
+#if REX_PLATFORM_LINUX
+  access_out = PageAccess::kNoAccess;
+  length = 0;
+
+  LinuxMapEntry e;
+  if (!FindEntryForAddressLinux(base_address, e)) {
+    return false;
+  }
+
+  const uintptr_t addr = reinterpret_cast<uintptr_t>(base_address);
+  length = static_cast<size_t>(e.end - addr);
+
+  const bool r = e.perms[0] == 'r';
+  const bool w = e.perms[1] == 'w';
+  const bool x = e.perms[2] == 'x';
+
+  if (!r && !w && !x) {
+    access_out = PageAccess::kNoAccess;
+  } else if (x) {
+    access_out = w ? PageAccess::kExecuteReadWrite
+                   : PageAccess::kExecuteReadOnly;
+  } else {
+    access_out = w ? PageAccess::kReadWrite : PageAccess::kReadOnly;
+  }
+
+  return true;
+
+#elif REX_PLATFORM_ANDROID
+  (void)base_address;
+  length = 0;
+  access_out = PageAccess::kNoAccess;
   return false;
+
+#elif REX_PLATFORM_MACOS
+  (void)base_address;
+  length = 0;
+  access_out = PageAccess::kNoAccess;
+  return false;
+
+#else
+#  error "Platform not supported."
+#endif
+}
+
+namespace {
+
+#if REX_PLATFORM_LINUX || REX_PLATFORM_MACOS
+static std::string MakeShmName(const std::filesystem::path& path) {
+  std::string name = path.string();
+  for (char& c : name) {
+    if (c == '/') c = '_';
+  }
+  if (name.empty() || name[0] != '/') {
+    name.insert(name.begin(), '/');
+  }
+  return name;
+}
+#endif
+
 }
 
 FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
@@ -128,7 +512,6 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
     int sharedmem_fd = android_ASharedMemory_create_(path.c_str(), length);
     return sharedmem_fd >= 0 ? sharedmem_fd : kFileMappingHandleInvalid;
   }
-
   // Use /dev/ashmem on API versions below 26, which added ASharedMemory.
   // /dev/ashmem was disabled on API 29 for apps targeting it.
   // https://chromium.googlesource.com/chromium/src/+/master/third_party/ashmem/ashmem-dev.c
@@ -144,52 +527,86 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path,
     return kFileMappingHandleInvalid;
   }
   return ashmem_fd;
-#else
+
+#elif REX_PLATFORM_LINUX || REX_PLATFORM_MACOS
+
   int oflag;
   switch (access) {
-    case PageAccess::kNoAccess:
-      oflag = 0;
-      break;
+    case PageAccess::kNoAccess: oflag = 0; break;
     case PageAccess::kReadOnly:
-    case PageAccess::kExecuteReadOnly:
-      oflag = O_RDONLY;
-      break;
+    case PageAccess::kExecuteReadOnly: oflag = O_RDONLY; break;
     case PageAccess::kReadWrite:
-    case PageAccess::kExecuteReadWrite:
-      oflag = O_RDWR;
-      break;
-    default:
-      assert_always();
-      return kFileMappingHandleInvalid;
+    case PageAccess::kExecuteReadWrite: oflag = O_RDWR; break;
+    default: assert_always(); return kFileMappingHandleInvalid;
   }
   oflag |= O_CREAT;
-  auto full_path = "/" / path;
-  int ret = shm_open(full_path.c_str(), oflag, 0777);
-  if (ret < 0) {
+
+  const std::string shm_name = MakeShmName(path);
+  const int fd = shm_open(shm_name.c_str(), oflag, 0777);
+  if (fd < 0) return kFileMappingHandleInvalid;
+
+  if (ftruncate(fd, static_cast<off_t>(length)) != 0) {
+    close(fd);
+    shm_unlink(shm_name.c_str());
     return kFileMappingHandleInvalid;
   }
-  ftruncate64(ret, length);
-  return ret;
+  return fd;
+
+#else
+#  error "Platform not supported."
 #endif
 }
 
 void CloseFileMappingHandle(FileMappingHandle handle,
                             const std::filesystem::path& path) {
   close(handle);
-#if !REX_PLATFORM_ANDROID
-  auto full_path = "/" / path;
-  shm_unlink(full_path.c_str());
+
+#if REX_PLATFORM_LINUX || REX_PLATFORM_MACOS
+  const std::string shm_name = MakeShmName(path);
+  shm_unlink(shm_name.c_str());
+#elif REX_PLATFORM_ANDROID
+  (void)path;
+#else
+#  error "Platform not supported."
 #endif
 }
 
 void* MapFileView(FileMappingHandle handle, void* base_address, size_t length,
                   PageAccess access, size_t file_offset) {
+  // POSIX requires mmap offset to be page-aligned.
+  const size_t page = static_cast<size_t>(getpagesize());
+  if (file_offset % page != 0) {
+    return nullptr;
+  }
+
   uint32_t prot = ToPosixProtectFlags(access);
-  void* result = mmap64(base_address, length, prot,
-                        MAP_SHARED | MAP_FIXED, handle, file_offset);
+  int flags = MAP_SHARED;
+
+#if REX_PLATFORM_LINUX
+  // If fixed was requested, we must either honor it or fail (no silent relocation).
+  void* requested = base_address;
+  base_address = SanitizeFixedBaseLinux(base_address, length);
+  if (requested && !base_address) {
+    return nullptr;
+  }
+#endif
+
+  flags |= PosixFixedFlagsFor(base_address);
+
+  void* result = mmap(base_address, length, static_cast<int>(prot), flags,
+                      handle, static_cast<off_t>(file_offset));
   if (result == MAP_FAILED) {
     return nullptr;
   }
+
+#if REX_PLATFORM_LINUX
+  // Extra safety: if fixed was requested, ensure we actually got it.
+  if (base_address && result != base_address) {
+    munmap(result, length);
+    return nullptr;
+  }
+#endif
+
   return result;
 }
 


### PR DESCRIPTION
Fixed Linux read write issues with files. 

- Make PosixFileHandle::Read/Write handle errors cleanly:
  * return false on pread/pwrite failure
  * avoid writing garbage into out_* when the syscall fails
- Populate FileInfo::total_size and type consistently in GetInfo

=====================================

Rework the POSIX memory backend to more closely match Windows-style
reserve/commit behavior and avoid unsafe MAP_FIXED usage.

Key changes:
- Implement reserve vs commit semantics using PROT_NONE + mprotect
- Prefer MAP_FIXED_NOREPLACE and refuse unsafe fixed-address mappings
- Emulate commit-on-reserve when mappings already exist
- Distinguish decommit vs release (mprotect+MADV_DONTNEED vs munmap)
- Add Linux /proc/self/maps introspection for QueryProtect and span inference
- Tighten file mapping behavior (page-aligned offsets, fixed-base validation)

<img width="1280" height="748" alt="image" src="https://github.com/user-attachments/assets/31bef2bb-df69-406a-ad3d-38622ae7a0d1" />