### PR TITLE
Add instructions vrfip128/vcmpgtsw./vcmpgtsh.

### DIFF
--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -425,6 +425,7 @@ bool build_vrfip(BuilderContext& ctx);
 bool build_vrfiz(BuilderContext& ctx);
 
 // Vector integer arithmetic
+bool build_vaddsbs(BuilderContext& ctx);
 bool build_vaddshs(BuilderContext& ctx);
 bool build_vaddsws(BuilderContext& ctx);
 bool build_vaddubm(BuilderContext& ctx);

--- a/src/codegen/builders/vector.cpp
+++ b/src/codegen/builders/vector.cpp
@@ -219,6 +219,12 @@ bool build_vrfiz(BuilderContext& ctx)
 // Vector Integer Arithmetic
 //=============================================================================
 
+bool build_vaddsbs(BuilderContext& ctx)
+{
+    ctx.emit_vec_int_binary("adds_epi8", "s8");
+    return true;
+}
+
 bool build_vaddshs(BuilderContext& ctx)
 {
     ctx.emit_vec_int_binary("adds_epi16", "s16");

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -410,6 +410,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable()
         //=====================================================================
         // Vector - Integer Arithmetic
         //=====================================================================
+        { PPC_INST_VADDSBS, build_vaddsbs },
         { PPC_INST_VADDSHS, build_vaddshs },
         { PPC_INST_VADDSWS, build_vaddsws },
         { PPC_INST_VADDUBM, build_vaddubm },


### PR DESCRIPTION
Pretty similar PR to rapid's. This adds codegen support for these formerly unimplemented VMX instructions:
- vrfip — vector round fp to int toward positive infinity
- vcmpgtsw — vector compare greater than signed word + including dotted/record form handling
- vcmpgtsh — vector compare greater than signed halfword + including dotted/record form handling
- vaddsbs — vector add signed byte saturating


Files changed:
- src/builders/vector.cpp — added implementations for all 3
- scr/builders.h — added declarations for all 3
- src/instruction_dispatch.cpp — added dispatch entry mappings for all 3