### PR TITLE
feat: add vsubuws instruction

### DIFF
--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -436,6 +436,7 @@ bool build_vadduws(BuilderContext& ctx);
 bool build_vsubshs(BuilderContext& ctx);
 bool build_vsubsws(BuilderContext& ctx);
 bool build_vsububs(BuilderContext& ctx);
+bool build_vsubuws(BuilderContext& ctx);
 bool build_vsubuhm(BuilderContext& ctx);
 bool build_vmaxsh(BuilderContext& ctx);
 bool build_vmaxsw(BuilderContext& ctx);

--- a/src/codegen/builders/vector.cpp
+++ b/src/codegen/builders/vector.cpp
@@ -304,6 +304,13 @@ bool build_vsububs(BuilderContext& ctx)
     return true;
 }
 
+bool build_vsubuws(BuilderContext& ctx)
+{
+    ctx.println("\tsimde_mm_store_si128((simde__m128i*){}.u32, simde_mm_sub_epi32(simde_mm_load_si128((simde__m128i*) {}.u32), simde_mm_min_epu32(simde_mm_load_si128((simde__m128i*){}.u32), simde_mm_load_si128((simde__m128i*){}.u32))));", 
+        ctx.v(ctx.insn.operands[0]), ctx.v(ctx.insn.operands[1]), ctx.v(ctx.insn.operands[1]), ctx.v(ctx.insn.operands[2]));
+    return true;
+}
+
 bool build_vsubuhm(BuilderContext& ctx)
 {
     ctx.emit_vec_int_binary("sub_epi16", "u8");

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -420,6 +420,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable()
         { PPC_INST_VADDUWS, build_vadduws },
         { PPC_INST_VSUBSWS, build_vsubsws },
         { PPC_INST_VSUBUBS, build_vsububs },
+        { PPC_INST_VSUBUWS, build_vsubuws },
         { PPC_INST_VSUBUHM, build_vsubuhm },
         { PPC_INST_VSUBSHS, build_vsubshs },
         { PPC_INST_VMAXSW, build_vmaxsw },


### PR DESCRIPTION
Adds codegen support for the vsubuws instruction:
- vsubuws — vector subtract unsigned word saturate

Files changed:
- src/codegen/builders.h — added declaration for vsubuws
- src/codegen/builders/vector.cpp — added implementation for vsubuws
- src/codegen/instruction_dispatch.cpp — added dispatch entry mappings for vsubuws