### PR TITLE
Use context from thread_state on thread execute

### DIFF
--- a/src/kernel/xthread.cpp
+++ b/src/kernel/xthread.cpp
@@ -536,7 +536,7 @@ void XThread::Execute() {
   }
 
   // Set up the PPCContext for execution
-  PPCContext ctx{};
+  PPCContext& ctx = *thread_state_->context();
   uint8_t* base = memory->virtual_membase();
 
   // Initialize critical registers (must match Xenia's ThreadState constructor)


### PR DESCRIPTION
Threads should be started with a context taking from thread_state_, so that later on the context can be accessed from kernel functions. Fixes #41.