### PR TITLE
Add memory oppcodes

### DIFF
--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -335,6 +335,7 @@ bool build_stfdx(BuilderContext& ctx);
 bool build_stfiwx(BuilderContext& ctx);
 bool build_stfs(BuilderContext& ctx);
 bool build_stfsu(BuilderContext& ctx);
+bool build_stfsux(BuilderContext& ctx);
 bool build_stfsx(BuilderContext& ctx);
 
 // Vector loads

--- a/src/codegen/builders/memory.cpp
+++ b/src/codegen/builders/memory.cpp
@@ -682,6 +682,25 @@ bool build_stfsu(BuilderContext& ctx)
     return true;
 }
 
+bool build_stfsux(BuilderContext& ctx)
+{
+    // Store Floating-point Single with Update Indexed
+    ctx.emit_set_flush_mode(false);
+    ctx.println("\t{}.f32 = float({}.f64);",
+        ctx.temp(), ctx.f(ctx.insn.operands[0]));
+    ctx.println("\t{} = {}.u32 + {}.u32;",
+        ctx.ea(),
+        ctx.r(ctx.insn.operands[1]),
+        ctx.r(ctx.insn.operands[2]));
+    ctx.println("\t{}({}, {}.u32);",
+        ctx.mmio_check_x_form() ? "PPC_MM_STORE_U32" : "PPC_STORE_U32",
+        ctx.ea(),
+        ctx.temp());
+    ctx.println("\t{}.u32 = {};",
+        ctx.r(ctx.insn.operands[1]), ctx.ea());
+    return true;
+}
+
 //=============================================================================
 // Vector Loads (will be more comprehensive in vector.cpp)
 //=============================================================================

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -248,6 +248,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable()
         { PPC_INST_STFIWX, build_stfiwx },
         { PPC_INST_STFS, build_stfs },
         { PPC_INST_STFSU, build_stfsu },
+        { PPC_INST_STFSUX, build_stfsux },
         { PPC_INST_STFSX, build_stfsx },
 
         //=====================================================================


### PR DESCRIPTION
Requested by @MaxDeadBear  - Needed for Silent Hill HD and other XBLA games

- lbzux — Load Byte and Zero with Update Indexed #45 
- stdux — Store Doubleword with Update Indexed #46 
- stbux — Store Byte with Update Indexed #47 
- ldux — Load Doubleword with Update Indexed #48 
- stfsux — Store Floating-Point Single with Update Indexed #49 

Files edited:
- src/builders/memory.cpp — added implementations for all 5
- src/builders.h — added declarations for all 5
- src/instruction_dispatch.cpp — added dispatch entry mappings for all 5