### PR TITLE
Roll-In Xenia Gamma Render Target UNorm16 Overhaul

### DIFF
--- a/include/rex/graphics/d3d12/render_target_cache.h
+++ b/include/rex/graphics/d3d12/render_target_cache.h
@@ -95,8 +95,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
 
   // For host render targets.
 
-  bool gamma_render_target_as_srgb() const {
-    return gamma_render_target_as_srgb_;
+  bool gamma_render_target_as_unorm16() const {
+    return gamma_render_target_as_unorm16_;
   }
 
   // Using R16G16[B16A16]_SNORM, which are -1...1, not the needed -32...32.
@@ -140,6 +140,8 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
 
   bool IsHostDepthEncodingDifferent(
       xenos::DepthRenderTargetFormat format) const override;
+
+  bool IsGammaFormatHostStorageSeparate() const override;
 
   void RequestPixelShaderInterlockBarrier() override;
 
@@ -225,16 +227,13 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
 
   class D3D12RenderTarget final : public RenderTarget {
    public:
-    // descriptor_draw_srgb is only used for k_8_8_8_8 render targets when host
-    // sRGB (gamma_render_target_as_srgb) is used. descriptor_load is present
-    // when the DXGI formats are different for drawing and bit-exact loading
-    // (for NaN pattern preservation across EDRAM tile ownership transfers in
-    // floating-point formats, and to distinguish between two -1 representations
-    // in snorm formats).
+    // descriptor_load_separate is present when the DXGI formats are different
+    // for drawing and bit-exact loading (for NaN pattern preservation across
+    // EDRAM tile ownership transfers in floating-point formats, and to
+    // distinguish between two -1 representations in snorm formats).
     D3D12RenderTarget(
         RenderTargetKey key, ID3D12Resource* resource,
         ui::d3d12::D3D12CpuDescriptorPool::Descriptor&& descriptor_draw,
-        ui::d3d12::D3D12CpuDescriptorPool::Descriptor&& descriptor_draw_srgb,
         ui::d3d12::D3D12CpuDescriptorPool::Descriptor&&
             descriptor_load_separate,
         ui::d3d12::D3D12CpuDescriptorPool::Descriptor&& descriptor_srv,
@@ -243,7 +242,6 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
         : RenderTarget(key),
           resource_(resource),
           descriptor_draw_(std::move(descriptor_draw)),
-          descriptor_draw_srgb_(std::move(descriptor_draw_srgb)),
           descriptor_load_separate_(std::move(descriptor_load_separate)),
           descriptor_srv_(std::move(descriptor_srv)),
           descriptor_srv_stencil_(std::move(descriptor_srv_stencil)),
@@ -253,10 +251,6 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
     const ui::d3d12::D3D12CpuDescriptorPool::Descriptor& descriptor_draw()
         const {
       return descriptor_draw_;
-    }
-    const ui::d3d12::D3D12CpuDescriptorPool::Descriptor& descriptor_draw_srgb()
-        const {
-      return descriptor_draw_srgb_;
     }
     const ui::d3d12::D3D12CpuDescriptorPool::Descriptor& descriptor_srv()
         const {
@@ -297,7 +291,6 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
    private:
     Microsoft::WRL::ComPtr<ID3D12Resource> resource_;
     ui::d3d12::D3D12CpuDescriptorPool::Descriptor descriptor_draw_;
-    ui::d3d12::D3D12CpuDescriptorPool::Descriptor descriptor_draw_srgb_;
     ui::d3d12::D3D12CpuDescriptorPool::Descriptor descriptor_load_separate_;
     // Texture SRV non-shader-visible descriptors, to prepare shader-visible
     // descriptors faster, by copying rather than by creating every time.
@@ -718,7 +711,7 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
 
   bool use_stencil_reference_output_ = false;
 
-  bool gamma_render_target_as_srgb_ = false;
+  bool gamma_render_target_as_unorm16_ = false;
 
   bool depth_float24_round_ = false;
   bool depth_float24_convert_in_pixel_shader_ = false;
@@ -753,7 +746,6 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
 
   const RenderTarget* const*
       current_command_list_render_targets_[1 + xenos::kMaxColorRenderTargets];
-  uint32_t are_current_command_list_render_targets_srgb_ = 0;
   bool are_current_command_list_render_targets_valid_ = false;
 
   // Temporary storage for descriptors used in PerformTransfersAndResolveClears

--- a/include/rex/graphics/flags.h
+++ b/include/rex/graphics/flags.h
@@ -30,7 +30,7 @@ REXCVAR_DECLARE(bool, depth_transfer_not_equal_test);
 // GPU Render Targets
 REXCVAR_DECLARE(bool, native_stencil_value_output);
 REXCVAR_DECLARE(bool, native_stencil_value_output_d3d12_intel);
-REXCVAR_DECLARE(bool, gamma_render_target_as_srgb);
+REXCVAR_DECLARE(bool, gamma_render_target_as_unorm16);
 REXCVAR_DECLARE(bool, native_2x_msaa);
 REXCVAR_DECLARE(bool, snorm16_render_target_full_range);
 REXCVAR_DECLARE(bool, mrt_edram_used_range_clamp_to_min);

--- a/include/rex/graphics/pipeline/shader/dxbc_translator.h
+++ b/include/rex/graphics/pipeline/shader/dxbc_translator.h
@@ -50,7 +50,7 @@ class DxbcShaderTranslator : public ShaderTranslator {
  public:
   DxbcShaderTranslator(ui::GraphicsProvider::GpuVendorID vendor_id,
                        bool bindless_resources_used, bool edram_rov_used,
-                       bool gamma_render_target_as_srgb = false,
+                       bool gamma_render_target_as_unorm8 = false,
                        bool msaa_2x_supported = true,
                        uint32_t draw_resolution_scale_x = 1,
                        uint32_t draw_resolution_scale_y = 1,
@@ -311,9 +311,8 @@ class DxbcShaderTranslator : public ShaderTranslator {
     // components of each of the 32 used texture fetch constants.
     uint32_t texture_swizzled_signs[8];
 
-    // Whether the contents of each texture in fetch constants comes from a
-    // resolve operation.
-    uint32_t textures_resolved;
+    // Whether each texture in fetch constants is resolution-scaled.
+    uint32_t textures_resolution_scaled;
     // Log2 of X and Y sample size. Used for alpha to mask, and for MSAA with
     // ROV, this is used for EDRAM address calculation.
     uint32_t sample_count_log2[2];
@@ -420,7 +419,7 @@ class DxbcShaderTranslator : public ShaderTranslator {
 
       kTextureSwizzledSigns,
 
-      kTexturesResolved,
+      kTexturesResolutionScaled,
       kSampleCountLog2,
       kAlphaTestReference,
 
@@ -573,6 +572,28 @@ class DxbcShaderTranslator : public ShaderTranslator {
                             uint32_t temp2_temp_component,
                             bool remap_to_0_to_0_5);
 
+  // Converts one scalar from piecewise linear gamma to linear. The target may
+  // be the same as the source, the temporary variables must be different. If
+  // the source is not pre-saturated, saturation will be done internally.
+  static void PWLGammaToLinear(dxbc::Assembler& a,
+                               uint32_t target_temp,
+                               uint32_t target_temp_component,
+                               uint32_t source_temp,
+                               uint32_t source_temp_component,
+                               bool source_pre_saturated, uint32_t temp1,
+                               uint32_t temp1_component, uint32_t temp2,
+                               uint32_t temp2_component);
+  // Converts one scalar, which must be saturated before calling this function,
+  // from linear to piecewise linear gamma. The target may be the same as either
+  // the source or as temp_or_target, but not as both (and temp_or_target may
+  // not be the same as the source). temp_non_target must be different.
+  static void PreSaturatedLinearToPWLGamma(
+      dxbc::Assembler& a,
+      uint32_t target_temp, uint32_t target_temp_component,
+      uint32_t source_temp, uint32_t source_temp_component,
+      uint32_t temp_or_target, uint32_t temp_or_target_component,
+      uint32_t temp_non_target, uint32_t temp_non_target_component);
+
  protected:
   void Reset() override;
 
@@ -683,24 +704,6 @@ class DxbcShaderTranslator : public ShaderTranslator {
   // before starting a new export or ending the invocation or making it
   // inactive.
   void ExportToMemory(uint8_t export_eM);
-
-  // Converts one scalar from piecewise linear gamma to linear. The target may
-  // be the same as the source, the temporary variables must be different. If
-  // the source is not pre-saturated, saturation will be done internally.
-  void PWLGammaToLinear(uint32_t target_temp, uint32_t target_temp_component,
-                        uint32_t source_temp, uint32_t source_temp_component,
-                        bool source_pre_saturated, uint32_t temp1,
-                        uint32_t temp1_component, uint32_t temp2,
-                        uint32_t temp2_component);
-  // Converts one scalar, which must be saturated before calling this function,
-  // from linear to piecewise linear gamma. The target may be the same as either
-  // the source or as temp_or_target, but not as both (and temp_or_target may
-  // not be the same as the source). temp_non_target must be different.
-  void PreSaturatedLinearToPWLGamma(
-      uint32_t target_temp, uint32_t target_temp_component,
-      uint32_t source_temp, uint32_t source_temp_component,
-      uint32_t temp_or_target, uint32_t temp_or_target_component,
-      uint32_t temp_non_target, uint32_t temp_non_target_component);
 
   bool IsSampleRate() const {
     assert_true(is_pixel_shader());
@@ -972,8 +975,8 @@ class DxbcShaderTranslator : public ShaderTranslator {
   bool edram_rov_used_;
 
   // Whether with RTV-based output-merger, k_8_8_8_8_GAMMA render targets are
-  // represented as host sRGB.
-  bool gamma_render_target_as_srgb_;
+  // stored as 8-bit with shader-side gamma conversion.
+  bool gamma_render_target_as_unorm8_;
 
   // Whether 2x MSAA is emulated using real 2x MSAA rather than two samples of
   // 4x MSAA.

--- a/include/rex/graphics/shared_memory.h
+++ b/include/rex/graphics/shared_memory.h
@@ -76,8 +76,7 @@ class SharedMemory {
   // Checks if the range has been updated, uploads new data if needed and
   // ensures the host GPU memory backing the range are resident. Returns true if
   // the range has been fully updated and is usable.
-  bool RequestRange(uint32_t start, uint32_t length,
-                    bool* any_data_resolved_out = nullptr);
+  bool RequestRange(uint32_t start, uint32_t length);
 
   // Marks the range and, if not exact_range, potentially its surroundings
   // (to up to the first GPU-written page, as an access violation exception
@@ -93,7 +92,7 @@ class SharedMemory {
   // be called, to make sure, if the GPU writes don't overwrite *everything* in
   // the pages they touch, the CPU data is properly loaded to the unmodified
   // regions in those pages.
-  void RangeWrittenByGpu(uint32_t start, uint32_t length, bool is_resolve);
+  void RangeWrittenByGpu(uint32_t start, uint32_t length);
 
  protected:
   SharedMemory(memory::Memory& memory);
@@ -127,8 +126,7 @@ class SharedMemory {
                                                 uint32_t length_allocations);
 
   // Mark the memory range as updated and protect it.
-  void MakeRangeValid(uint32_t start, uint32_t length, bool written_by_gpu,
-                      bool written_by_gpu_resolve);
+  void MakeRangeValid(uint32_t start, uint32_t length, bool written_by_gpu);
 
   // Uploads a range of host pages - only called if host GPU sparse memory
   // allocation succeeded if needed. While uploading, MakeRangeValid must be
@@ -197,9 +195,6 @@ class SharedMemory {
     // Subset of valid pages - whether each page in the GPU buffer contains data
     // that was written on the GPU, thus should not be invalidated spuriously.
     uint64_t valid_and_gpu_written;
-    // Subset of valid_and_gpu_written - whether each page in the GPU buffer
-    // contains data written specifically by resolving from EDRAM.
-    uint64_t valid_and_gpu_resolved;
   };
   // Flags for each 64 system pages, interleaved as blocks, so bit scan can be
   // used to quickly extract ranges.

--- a/include/rex/graphics/vulkan/render_target_cache.h
+++ b/include/rex/graphics/vulkan/render_target_cache.h
@@ -191,6 +191,8 @@ class VulkanRenderTargetCache final : public RenderTargetCache {
   bool IsHostDepthEncodingDifferent(
       xenos::DepthRenderTargetFormat format) const override;
 
+  bool IsGammaFormatHostStorageSeparate() const override;
+
   void RequestPixelShaderInterlockBarrier() override;
 
  private:
@@ -863,7 +865,7 @@ class VulkanRenderTargetCache final : public RenderTargetCache {
   void DumpRenderTargets(uint32_t dump_base, uint32_t dump_row_length_used,
                          uint32_t dump_rows, uint32_t dump_pitch);
 
-  bool gamma_render_target_as_srgb_ = false;
+  bool gamma_render_target_as_unorm16_ = false;
 
   bool depth_unorm24_vulkan_format_supported_ = false;
   bool depth_float24_round_ = false;

--- a/src/graphics/d3d12/command_processor.cpp
+++ b/src/graphics/d3d12/command_processor.cpp
@@ -2227,7 +2227,6 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
   if (host_render_targets_used) {
     bound_depth_and_color_render_target_bits =
         render_target_cache_->GetLastUpdateBoundRenderTargets(
-            render_target_cache_->gamma_render_target_as_srgb(),
             bound_depth_and_color_render_target_formats);
   } else {
     bound_depth_and_color_render_target_bits = 0;
@@ -2520,8 +2519,8 @@ bool D3D12CommandProcessor::IssueDraw(xenos::PrimitiveType primitive_type,
     // Invalidate textures in memexported memory and watch for changes.
     for (const draw_util::MemExportRange& memexport_range : memexport_ranges_) {
       shared_memory_->RangeWrittenByGpu(
-          memexport_range.base_address_dwords << 2, memexport_range.size_bytes,
-          false);
+          memexport_range.base_address_dwords << 2,
+          memexport_range.size_bytes);
     }
     if (REXCVAR_GET(d3d12_readback_memexport)) {
       // Read the exported data on the CPU.
@@ -3207,7 +3206,7 @@ void D3D12CommandProcessor::UpdateSystemConstantValues(
   flags |= uint32_t(alpha_test_function)
            << DxbcShaderTranslator::kSysFlag_AlphaPassIfLess_Shift;
   // Gamma writing.
-  if (!render_target_cache_->gamma_render_target_as_srgb()) {
+  if (!render_target_cache_->gamma_render_target_as_unorm16()) {
     for (uint32_t i = 0; i < 4; ++i) {
       if (color_infos[i].color_format ==
           xenos::ColorRenderTargetFormat::k_8_8_8_8_GAMMA) {
@@ -3348,9 +3347,7 @@ void D3D12CommandProcessor::UpdateSystemConstantValues(
   }
 
   // Texture signedness / gamma.
-  bool gamma_render_target_as_srgb =
-      render_target_cache_->gamma_render_target_as_srgb();
-  uint32_t textures_resolved = 0;
+  uint32_t textures_resolution_scaled = 0;
   uint32_t textures_remaining = used_texture_mask;
   uint32_t texture_index;
   while (rex::bit_scan_forward(textures_remaining, &texture_index)) {
@@ -3366,12 +3363,12 @@ void D3D12CommandProcessor::UpdateSystemConstantValues(
     dirty |= (texture_signs_uint & texture_signs_mask) != texture_signs_shifted;
     texture_signs_uint =
         (texture_signs_uint & ~texture_signs_mask) | texture_signs_shifted;
-    textures_resolved |=
-        uint32_t(texture_cache_->IsActiveTextureResolved(texture_index))
+    textures_resolution_scaled |=
+        uint32_t(texture_cache_->IsActiveTextureResolutionScaled(texture_index))
         << texture_index;
   }
-  dirty |= system_constants_.textures_resolved != textures_resolved;
-  system_constants_.textures_resolved = textures_resolved;
+  dirty |= system_constants_.textures_resolution_scaled != textures_resolution_scaled;
+  system_constants_.textures_resolution_scaled = textures_resolution_scaled;
 
   // Log2 of sample count, for alpha to mask and with ROV, for EDRAM address
   // calculation with MSAA.

--- a/src/graphics/d3d12/pipeline_cache.cpp
+++ b/src/graphics/d3d12/pipeline_cache.cpp
@@ -100,7 +100,7 @@ PipelineCache::PipelineCache(D3D12CommandProcessor& command_processor,
 
   shader_translator_ = std::make_unique<DxbcShaderTranslator>(
       provider.GetAdapterVendorID(), bindless_resources_used_, edram_rov_used,
-      render_target_cache_.gamma_render_target_as_srgb(),
+      !render_target_cache_.gamma_render_target_as_unorm16(),
       render_target_cache_.msaa_2x_supported(),
       render_target_cache_.draw_resolution_scale_x(),
       render_target_cache_.draw_resolution_scale_y(),
@@ -393,7 +393,7 @@ void PipelineCache::InitializeShaderStorage(
       string::StringBuffer ucode_disasm_buffer;
       DxbcShaderTranslator translator(
           provider.GetAdapterVendorID(), bindless_resources_used_,
-          edram_rov_used, render_target_cache_.gamma_render_target_as_srgb(),
+          edram_rov_used, !render_target_cache_.gamma_render_target_as_unorm16(),
           render_target_cache_.msaa_2x_supported(),
           render_target_cache_.draw_resolution_scale_x(),
           render_target_cache_.draw_resolution_scale_y(),

--- a/src/graphics/d3d12/shared_memory.cpp
+++ b/src/graphics/d3d12/shared_memory.cpp
@@ -429,7 +429,7 @@ bool D3D12SharedMemory::UploadRanges(
         return false;
       }
       MakeRangeValid(upload_range_start << page_size_log2(),
-                     uint32_t(upload_buffer_size), false, false);
+                     uint32_t(upload_buffer_size), false);
       std::memcpy(
           upload_buffer_mapping,
           memory().TranslatePhysical(upload_range_start << page_size_log2()),

--- a/src/graphics/pipeline/render_target/cache.cpp
+++ b/src/graphics/pipeline/render_target/cache.cpp
@@ -471,7 +471,6 @@ bool RenderTargetCache::Update(bool is_rasterization_done,
   uint32_t edram_bases[1 + xenos::kMaxColorRenderTargets];
   uint32_t resource_formats[1 + xenos::kMaxColorRenderTargets];
   uint32_t rts_are_64bpp = 0;
-  uint32_t color_rts_are_gamma = 0;
   if (is_rasterization_done) {
     if (normalized_depth_control.z_enable ||
         normalized_depth_control.stencil_enable) {
@@ -499,9 +498,6 @@ bool RenderTargetCache::Update(bool is_rasterization_done,
       bool is_64bpp = xenos::IsColorRenderTargetFormat64bpp(color_format);
       if (is_64bpp) {
         rts_are_64bpp |= uint32_t(1) << rt_bit_index;
-      }
-      if (color_format == xenos::ColorRenderTargetFormat::k_8_8_8_8_GAMMA) {
-        color_rts_are_gamma |= uint32_t(1) << i;
       }
       xenos::ColorRenderTargetFormat color_resource_format;
       if (interlock_barrier_only) {
@@ -588,7 +584,6 @@ bool RenderTargetCache::Update(bool is_rasterization_done,
     if (!are_accumulated_render_targets_valid_) {
       std::memset(last_update_accumulated_render_targets_, 0,
                   sizeof(last_update_accumulated_render_targets_));
-      last_update_accumulated_color_targets_are_gamma_ = 0;
     }
     return true;
   }
@@ -797,26 +792,13 @@ bool RenderTargetCache::Update(bool is_rasterization_done,
     std::memcpy(last_update_accumulated_render_targets_,
                 last_update_used_render_targets_,
                 sizeof(last_update_accumulated_render_targets_));
-    last_update_accumulated_color_targets_are_gamma_ = 0;
     are_accumulated_render_targets_valid_ = true;
   }
-  // Only update color space of render targets that actually matter here, don't
-  // disable gamma emulation (which may require ending the render pass) on the
-  // host, for example, if making a depth-only draw between color draws with a
-  // gamma target.
-  uint32_t color_rts_used_bits = depth_and_color_rts_used_bits >> 1;
-  // Ignore any render targets dropped before in this function for any reason.
-  color_rts_are_gamma &= color_rts_used_bits;
-  last_update_accumulated_color_targets_are_gamma_ =
-      (last_update_accumulated_color_targets_are_gamma_ &
-       ~color_rts_used_bits) |
-      color_rts_are_gamma;
 
   return true;
 }
 
 uint32_t RenderTargetCache::GetLastUpdateBoundRenderTargets(
-    bool distinguish_gamma_formats,
     uint32_t* depth_and_color_formats_out) const {
   if (GetPath() != Path::kHostRenderTargets) {
     if (depth_and_color_formats_out) {
@@ -837,12 +819,7 @@ uint32_t RenderTargetCache::GetLastUpdateBoundRenderTargets(
     }
     rts_used |= uint32_t(1) << i;
     if (depth_and_color_formats_out) {
-      depth_and_color_formats_out[i] =
-          (distinguish_gamma_formats && i &&
-           (last_update_accumulated_color_targets_are_gamma_ &
-            (uint32_t(1) << (i - 1))))
-              ? uint32_t(xenos::ColorRenderTargetFormat::k_8_8_8_8_GAMMA)
-              : render_target->key().resource_format;
+      depth_and_color_formats_out[i] = render_target->key().resource_format;
     }
   }
   return rts_used;

--- a/src/graphics/pipeline/shader/dxbc_translator.cpp
+++ b/src/graphics/pipeline/shader/dxbc_translator.cpp
@@ -62,7 +62,7 @@ using namespace ucode;
 
 DxbcShaderTranslator::DxbcShaderTranslator(
     ui::GraphicsProvider::GpuVendorID vendor_id, bool bindless_resources_used,
-    bool edram_rov_used, bool gamma_render_target_as_srgb,
+    bool edram_rov_used, bool gamma_render_target_as_unorm8,
     bool msaa_2x_supported, uint32_t draw_resolution_scale_x,
     uint32_t draw_resolution_scale_y, bool force_emit_source_map)
     : a_(shader_code_, statistics_),
@@ -70,7 +70,7 @@ DxbcShaderTranslator::DxbcShaderTranslator(
       vendor_id_(vendor_id),
       bindless_resources_used_(bindless_resources_used),
       edram_rov_used_(edram_rov_used),
-      gamma_render_target_as_srgb_(gamma_render_target_as_srgb),
+      gamma_render_target_as_unorm8_(gamma_render_target_as_unorm8),
       msaa_2x_supported_(msaa_2x_supported),
       draw_resolution_scale_x_(draw_resolution_scale_x),
       draw_resolution_scale_y_(draw_resolution_scale_y),
@@ -217,9 +217,10 @@ void DxbcShaderTranslator::PopSystemTemp(uint32_t count) {
 }
 
 void DxbcShaderTranslator::PWLGammaToLinear(
-    uint32_t target_temp, uint32_t target_temp_component, uint32_t source_temp,
-    uint32_t source_temp_component, bool source_pre_saturated, uint32_t temp1,
-    uint32_t temp1_component, uint32_t temp2, uint32_t temp2_component) {
+    dxbc::Assembler& a, uint32_t target_temp, uint32_t target_temp_component,
+    uint32_t source_temp, uint32_t source_temp_component,
+    bool source_pre_saturated, uint32_t temp1, uint32_t temp1_component,
+    uint32_t temp2, uint32_t temp2_component) {
   // The source is needed only once to begin building the result, so it can be
   // the same as the destination.
   assert_true(temp1 != target_temp || temp1_component != target_temp_component);
@@ -240,25 +241,25 @@ void DxbcShaderTranslator::PWLGammaToLinear(
   // Using `source >= threshold` comparisons because the input might have not
   // been saturated yet, and thus it may be NaN - since it will be saturated to
   // 0 later, the 0...64/255 case should be selected for it.
-  a_.OpGE(temp2_dest, source_src, dxbc::Src::LF(96.0f / 255.0f));
-  a_.OpIf(true, temp2_src);
+  a.OpGE(temp2_dest, source_src, dxbc::Src::LF(96.0f / 255.0f));
+  a.OpIf(true, temp2_src);
   // [96/255 ... 1
-  a_.OpGE(temp2_dest, source_src, dxbc::Src::LF(192.0f / 255.0f));
-  a_.OpMovC(temp1_dest, temp2_src, dxbc::Src::LF(8.0f / 1024.0f),
-            dxbc::Src::LF(4.0f / 1024.0f));
-  a_.OpMovC(temp2_dest, temp2_src, dxbc::Src::LF(-1024.0f),
-            dxbc::Src::LF(-256.0f));
-  a_.OpElse();
+  a.OpGE(temp2_dest, source_src, dxbc::Src::LF(192.0f / 255.0f));
+  a.OpMovC(temp1_dest, temp2_src, dxbc::Src::LF(8.0f / 1024.0f),
+           dxbc::Src::LF(4.0f / 1024.0f));
+  a.OpMovC(temp2_dest, temp2_src, dxbc::Src::LF(-1024.0f),
+           dxbc::Src::LF(-256.0f));
+  a.OpElse();
   // 0 ... 96/255)
-  a_.OpGE(temp2_dest, source_src, dxbc::Src::LF(64.0f / 255.0f));
-  a_.OpMovC(temp1_dest, temp2_src, dxbc::Src::LF(2.0f / 1024.0f),
-            dxbc::Src::LF(1.0f / 1024.0f));
-  a_.OpMovC(temp2_dest, temp2_src, dxbc::Src::LF(-64.0f), dxbc::Src::LF(0.0f));
-  a_.OpEndIf();
+  a.OpGE(temp2_dest, source_src, dxbc::Src::LF(64.0f / 255.0f));
+  a.OpMovC(temp1_dest, temp2_src, dxbc::Src::LF(2.0f / 1024.0f),
+           dxbc::Src::LF(1.0f / 1024.0f));
+  a.OpMovC(temp2_dest, temp2_src, dxbc::Src::LF(-64.0f), dxbc::Src::LF(0.0f));
+  a.OpEndIf();
 
   if (!source_pre_saturated) {
     // Saturate the input, and flush NaN to 0.
-    a_.OpMov(target_dest, source_src, true);
+    a.OpMov(target_dest, source_src, true);
   }
   // linear = gamma * (255 * 1024) * scale + offset
   // As both 1024 and the scale are powers of 2, and 1024 * scale is not smaller
@@ -267,22 +268,22 @@ void DxbcShaderTranslator::PWLGammaToLinear(
   // gamma * (255 * 1024 * scale) - or the option chosen here, as long as
   // 1024 is applied before the scale since the scale is < 1 (specifically at
   // least 1/1024), and it may make very small values denormal.
-  a_.OpMul(target_dest, source_pre_saturated ? source_src : target_src,
-           dxbc::Src::LF(255.0f * 1024.0f));
-  a_.OpMAd(target_dest, target_src, temp1_src, temp2_src);
+  a.OpMul(target_dest, source_pre_saturated ? source_src : target_src,
+          dxbc::Src::LF(255.0f * 1024.0f));
+  a.OpMAd(target_dest, target_src, temp1_src, temp2_src);
   // linear += trunc(linear * scale)
-  a_.OpMul(temp1_dest, target_src, temp1_src);
-  a_.OpRoundZ(temp1_dest, temp1_src);
-  a_.OpAdd(target_dest, target_src, temp1_src);
+  a.OpMul(temp1_dest, target_src, temp1_src);
+  a.OpRoundZ(temp1_dest, temp1_src);
+  a.OpAdd(target_dest, target_src, temp1_src);
   // linear *= 1/1023
-  a_.OpMul(target_dest, target_src, dxbc::Src::LF(1.0f / 1023.0f));
+  a.OpMul(target_dest, target_src, dxbc::Src::LF(1.0f / 1023.0f));
 }
 
 void DxbcShaderTranslator::PreSaturatedLinearToPWLGamma(
-    uint32_t target_temp, uint32_t target_temp_component, uint32_t source_temp,
-    uint32_t source_temp_component, uint32_t temp_or_target,
-    uint32_t temp_or_target_component, uint32_t temp_non_target,
-    uint32_t temp_non_target_component) {
+    dxbc::Assembler& a, uint32_t target_temp, uint32_t target_temp_component,
+    uint32_t source_temp, uint32_t source_temp_component,
+    uint32_t temp_or_target, uint32_t temp_or_target_component,
+    uint32_t temp_non_target, uint32_t temp_non_target_component) {
   // The source may be the same as the target, but in this case it can't also be
   // used as a temporary variable.
   assert_true(target_temp != source_temp ||
@@ -312,28 +313,28 @@ void DxbcShaderTranslator::PreSaturatedLinearToPWLGamma(
 
   // Get the scale (into temp_or_target) and the offset (into temp_non_target)
   // for the piece.
-  a_.OpGE(temp_non_target_dest, source_src, dxbc::Src::LF(128.0f / 1023.0f));
-  a_.OpIf(true, temp_non_target_src);
+  a.OpGE(temp_non_target_dest, source_src, dxbc::Src::LF(128.0f / 1023.0f));
+  a.OpIf(true, temp_non_target_src);
   // [128/1023 ... 1
-  a_.OpGE(temp_non_target_dest, source_src, dxbc::Src::LF(512.0f / 1023.0f));
-  a_.OpMovC(temp_or_target_dest, temp_non_target_src,
-            dxbc::Src::LF(1023.0f / 8.0f), dxbc::Src::LF(1023.0f / 4.0f));
-  a_.OpMovC(temp_non_target_dest, temp_non_target_src,
-            dxbc::Src::LF(128.0f / 255.0f), dxbc::Src::LF(64.0f / 255.0f));
-  a_.OpElse();
+  a.OpGE(temp_non_target_dest, source_src, dxbc::Src::LF(512.0f / 1023.0f));
+  a.OpMovC(temp_or_target_dest, temp_non_target_src,
+           dxbc::Src::LF(1023.0f / 8.0f), dxbc::Src::LF(1023.0f / 4.0f));
+  a.OpMovC(temp_non_target_dest, temp_non_target_src,
+           dxbc::Src::LF(128.0f / 255.0f), dxbc::Src::LF(64.0f / 255.0f));
+  a.OpElse();
   // 0 ... 128/1023)
-  a_.OpGE(temp_non_target_dest, source_src, dxbc::Src::LF(64.0f / 1023.0f));
-  a_.OpMovC(temp_or_target_dest, temp_non_target_src,
-            dxbc::Src::LF(1023.0f / 2.0f), dxbc::Src::LF(1023.0f));
-  a_.OpMovC(temp_non_target_dest, temp_non_target_src,
-            dxbc::Src::LF(32.0f / 255.0f), dxbc::Src::LF(0.0f));
-  a_.OpEndIf();
+  a.OpGE(temp_non_target_dest, source_src, dxbc::Src::LF(64.0f / 1023.0f));
+  a.OpMovC(temp_or_target_dest, temp_non_target_src,
+           dxbc::Src::LF(1023.0f / 2.0f), dxbc::Src::LF(1023.0f));
+  a.OpMovC(temp_non_target_dest, temp_non_target_src,
+           dxbc::Src::LF(32.0f / 255.0f), dxbc::Src::LF(0.0f));
+  a.OpEndIf();
 
   // gamma = trunc(linear * scale) * (1.0 / 255.0) + offset
-  a_.OpMul(target_dest, source_src, temp_or_target_src);
-  a_.OpRoundZ(target_dest, target_src);
-  a_.OpMAd(target_dest, target_src, dxbc::Src::LF(1.0f / 255.0f),
-           temp_non_target_src);
+  a.OpMul(target_dest, source_src, temp_or_target_src);
+  a.OpRoundZ(target_dest, target_src);
+  a.OpMAd(target_dest, target_src, dxbc::Src::LF(1.0f / 255.0f),
+          temp_non_target_src);
 }
 
 void DxbcShaderTranslator::RemapAndConvertVertexIndices(
@@ -2130,7 +2131,7 @@ const DxbcShaderTranslator::SystemConstantRdef
         {"xe_texture_swizzled_signs", ShaderRdefTypeIndex::kUint4Array2,
          sizeof(uint32_t) * 4 * 2},
 
-        {"xe_textures_resolved", ShaderRdefTypeIndex::kUint, sizeof(uint32_t)},
+        {"xe_textures_resolution_scaled", ShaderRdefTypeIndex::kUint, sizeof(uint32_t)},
         {"xe_sample_count_log2", ShaderRdefTypeIndex::kUint2,
          sizeof(uint32_t) * 2},
         {"xe_alpha_test_reference", ShaderRdefTypeIndex::kFloat, sizeof(float)},

--- a/src/graphics/pipeline/shader/dxbc_translator_fetch.cpp
+++ b/src/graphics/pipeline/shader/dxbc_translator_fetch.cpp
@@ -984,16 +984,16 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
         coord_src = dxbc::Src::R(system_temp_result_);
       }
       // Using system_temp_result_.w as a temporary for the flag indicating
-      // whether the texture was resolved - not involved in coordinate
+      // whether the texture is resolution-scaled - not involved in coordinate
       // calculations.
       assert_zero(used_result_nonzero_components & 0b1000);
       a_.OpAnd(dxbc::Dest::R(system_temp_result_, 0b1000),
-               LoadSystemConstant(SystemConstants::Index::kTexturesResolved,
-                                  offsetof(SystemConstants, textures_resolved),
+               LoadSystemConstant(SystemConstants::Index::kTexturesResolutionScaled,
+                                  offsetof(SystemConstants, textures_resolution_scaled),
                                   dxbc::Src::kXXXX),
                dxbc::Src::LU(uint32_t(1) << tfetch_index));
       a_.OpIf(true, dxbc::Src::R(system_temp_result_, dxbc::Src::kWWWW));
-      // The texture is resolved - scale the coordinates and the size.
+      // The texture is resolution-scaled - scale the coordinates and the size.
       dxbc::Src resolution_scale_src(
           dxbc::Src::LF(float(draw_resolution_scale_x_),
                         float(draw_resolution_scale_y_), 1.0f, 1.0f));
@@ -1112,8 +1112,8 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
           // resolution scale inverse - sampler not loaded yet.
           a_.OpAnd(
               dxbc::Dest::R(coord_and_sampler_temp, 0b1000),
-              LoadSystemConstant(SystemConstants::Index::kTexturesResolved,
-                                 offsetof(SystemConstants, textures_resolved),
+              LoadSystemConstant(SystemConstants::Index::kTexturesResolutionScaled,
+                                 offsetof(SystemConstants, textures_resolution_scaled),
                                  dxbc::Src::kXXXX),
               dxbc::Src::LU(uint32_t(1) << tfetch_index));
           a_.OpIf(true, dxbc::Src::R(coord_and_sampler_temp, dxbc::Src::kWWWW));
@@ -1181,8 +1181,8 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
           // resolution scale inverse - sampler not loaded yet.
           a_.OpAnd(
               dxbc::Dest::R(coord_and_sampler_temp, 0b1000),
-              LoadSystemConstant(SystemConstants::Index::kTexturesResolved,
-                                 offsetof(SystemConstants, textures_resolved),
+              LoadSystemConstant(SystemConstants::Index::kTexturesResolutionScaled,
+                                 offsetof(SystemConstants, textures_resolution_scaled),
                                  dxbc::Src::kXXXX),
               dxbc::Src::LU(uint32_t(1) << tfetch_index));
           a_.OpIf(true, dxbc::Src::R(coord_and_sampler_temp, dxbc::Src::kWWWW));
@@ -2097,56 +2097,9 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
         a_.OpBreak();
         a_.OpCase(dxbc::Src::LU(uint32_t(xenos::TextureSign::kGamma)));
         uint32_t gamma_temp = PushSystemTemp();
-        if (gamma_render_target_as_srgb_) {
-          // Check if the texture has sRGB rather that piecewise linear gamma.
-          // More likely that it's just a texture with PWL, put this case in the
-          // `if`, with `else` for sRGB resolved render targets.
-          a_.OpAnd(
-              dxbc::Dest::R(gamma_temp, 0b0001),
-              LoadSystemConstant(SystemConstants::Index::kTexturesResolved,
-                                 offsetof(SystemConstants, textures_resolved),
-                                 dxbc::Src::kXXXX),
-              dxbc::Src::LU(uint32_t(1) << tfetch_index));
-          a_.OpIf(false, dxbc::Src::R(gamma_temp, dxbc::Src::kXXXX));
-        }
         // Convert from piecewise linear.
-        PWLGammaToLinear(system_temp_result_, i, system_temp_result_, i, false,
-                         gamma_temp, 0, gamma_temp, 1);
-        if (gamma_render_target_as_srgb_) {
-          a_.OpElse();
-          // Convert from sRGB.
-          a_.OpMov(component_dest, component_src, true);
-          a_.OpGE(dxbc::Dest::R(gamma_temp, 0b0001),
-                  dxbc::Src::LF(RenderTargetCache::kSrgbToLinearThreshold),
-                  component_src);
-          a_.OpIf(true, dxbc::Src::R(gamma_temp, dxbc::Src::kXXXX));
-          // sRGB <= kSrgbToLinearThreshold case - linear scale.
-          a_.OpMul(component_dest, component_src,
-                   dxbc::Src::LF(1.0f /
-                                 RenderTargetCache::kSrgbToLinearDenominator1));
-          a_.OpElse();
-          // sRGB > kSrgbToLinearThreshold case.
-          // 0 and 1 must be exactly achievable - only convert when the
-          // saturated value is < 1.
-          a_.OpLT(dxbc::Dest::R(gamma_temp, 0b0001), component_src,
-                  dxbc::Src::LF(1.0f));
-          a_.OpIf(true, dxbc::Src::R(gamma_temp, dxbc::Src::kXXXX));
-          a_.OpMAd(component_dest, component_src,
-                   dxbc::Src::LF(1.0f /
-                                 RenderTargetCache::kSrgbToLinearDenominator2),
-                   dxbc::Src::LF(RenderTargetCache::kSrgbToLinearOffset /
-                                 RenderTargetCache::kSrgbToLinearDenominator2));
-          a_.OpLog(component_dest, component_src);
-          a_.OpMul(component_dest, component_src,
-                   dxbc::Src::LF(RenderTargetCache::kSrgbToLinearExponent));
-          a_.OpExp(component_dest, component_src);
-          // Close the < 1 check.
-          a_.OpEndIf();
-          // Close the sRGB <= kSrgbToLinearThreshold check.
-          a_.OpEndIf();
-          // Close the PWL or sRGB check.
-          a_.OpEndIf();
-        }
+        PWLGammaToLinear(a_, system_temp_result_, i, system_temp_result_, i,
+                         false, gamma_temp, 0, gamma_temp, 1);
         // Release gamma_temp.
         PopSystemTemp();
         a_.OpBreak();

--- a/src/graphics/pipeline/shader/dxbc_translator_om.cpp
+++ b/src/graphics/pipeline/shader/dxbc_translator_om.cpp
@@ -1192,7 +1192,7 @@ void DxbcShaderTranslator::ROV_UnpackColor(
              dxbc::Src::LF(1.0f / 255.0f));
     if (i) {
       for (uint32_t j = 0; j < 3; ++j) {
-        PWLGammaToLinear(color_temp, j, color_temp, j, true, temp1,
+        PWLGammaToLinear(a_, color_temp, j, color_temp, j, true, temp1,
                          temp1_component, temp2, temp2_component);
       }
     }
@@ -1345,7 +1345,7 @@ void DxbcShaderTranslator::ROV_PackPreClampedColor(
           : xenos::ColorRenderTargetFormat::k_8_8_8_8)));
     for (uint32_t j = 0; j < 4; ++j) {
       if (i && j < 3) {
-        PreSaturatedLinearToPWLGamma(temp1, temp1_component, color_temp, j,
+        PreSaturatedLinearToPWLGamma(a_, temp1, temp1_component, color_temp, j,
                                      temp1, temp1_component, temp2,
                                      temp2_component);
         // Denormalize and add 0.5 for rounding.
@@ -1680,7 +1680,7 @@ void DxbcShaderTranslator::CompletePixelShader_WriteToRTVs() {
                  SystemConstants::Index::kColorExpBias,
                  offsetof(SystemConstants, color_exp_bias) + sizeof(float) * i,
                  dxbc::Src::kXXXX));
-    if (!gamma_render_target_as_srgb_) {
+    if (gamma_render_target_as_unorm8_) {
       // Convert to gamma space - this is incorrect, since it must be done after
       // blending on the Xbox 360, but this is just one of many blending issues
       // in the RTV path.
@@ -1691,8 +1691,9 @@ void DxbcShaderTranslator::CompletePixelShader_WriteToRTVs() {
       a_.OpMov(dxbc::Dest::R(system_temp_color, 0b0111),
                dxbc::Src::R(system_temp_color), true);
       for (uint32_t j = 0; j < 3; ++j) {
-        PreSaturatedLinearToPWLGamma(system_temp_color, j, system_temp_color, j,
-                                     gamma_temp, 0, gamma_temp, 1);
+        PreSaturatedLinearToPWLGamma(a_, system_temp_color, j,
+                                     system_temp_color, j, gamma_temp, 0,
+                                     gamma_temp, 1);
       }
       a_.OpEndIf();
     }

--- a/src/graphics/pipeline/texture/cache.cpp
+++ b/src/graphics/pipeline/texture/cache.cpp
@@ -329,7 +329,7 @@ void TextureCache::MarkRangeAsResolved(uint32_t start_unscaled,
 
   // Invalidate textures. Toggling individual textures between scaled and
   // unscaled also relies on invalidation through shared memory.
-  shared_memory().RangeWrittenByGpu(start_unscaled, length_unscaled, true);
+  shared_memory().RangeWrittenByGpu(start_unscaled, length_unscaled);
 }
 
 uint32_t TextureCache::GuestToHostSwizzle(uint32_t guest_swizzle,
@@ -501,8 +501,6 @@ TextureCache::Texture::Texture(TextureCache& texture_cache,
     : texture_cache_(texture_cache),
       key_(key),
       guest_layout_(key.GetGuestLayout()),
-      base_resolved_(key.scaled_resolve),
-      mips_resolved_(key.scaled_resolve),
       last_usage_submission_index_(texture_cache.current_submission_index_),
       last_usage_time_(texture_cache.current_submission_time_),
       used_previous_(texture_cache.texture_used_last_),
@@ -705,21 +703,17 @@ bool TextureCache::LoadTextureData(Texture& texture) {
   // its pages is invalidated, in this case we'll need the texture from the
   // shared memory to load the unscaled parts.
   // TODO(Triang3l): Load unscaled parts.
-  bool base_resolved = texture.GetBaseResolved();
   if (base_outdated) {
     if (!shared_memory().RequestRange(
             texture_key.base_page << 12,
-            rex::align(texture.GetGuestBaseSize(), UINT32_C(16)),
-            texture_key.scaled_resolve ? nullptr : &base_resolved)) {
+            rex::align(texture.GetGuestBaseSize(), UINT32_C(16)))) {
       return false;
     }
   }
-  bool mips_resolved = texture.GetMipsResolved();
   if (mips_outdated) {
     if (!shared_memory().RequestRange(
             texture_key.mip_page << 12,
-            rex::align(texture.GetGuestMipsSize(), UINT32_C(16)),
-            texture_key.scaled_resolve ? nullptr : &mips_resolved)) {
+            rex::align(texture.GetGuestMipsSize(), UINT32_C(16)))) {
       return false;
     }
   }
@@ -742,14 +736,6 @@ bool TextureCache::LoadTextureData(Texture& texture) {
   if (!LoadTextureDataFromResidentMemoryImpl(texture, base_outdated,
                                              mips_outdated)) {
     return false;
-  }
-
-  // Update the source of the texture (resolve vs. CPU or memexport) for
-  // purposes of handling piecewise gamma emulation via sRGB and for resolution
-  // scale in sampling offsets.
-  if (!texture_key.scaled_resolve) {
-    texture.SetBaseResolved(base_resolved);
-    texture.SetMipsResolved(mips_resolved);
   }
 
   // Mark the ranges as uploaded and watch them. This is needed for scaled

--- a/src/graphics/shared_memory.cpp
+++ b/src/graphics/shared_memory.cpp
@@ -247,8 +247,7 @@ void SharedMemory::FireWatches(uint32_t page_first, uint32_t page_last,
   }
 }
 
-void SharedMemory::RangeWrittenByGpu(uint32_t start, uint32_t length,
-                                     bool is_resolve) {
+void SharedMemory::RangeWrittenByGpu(uint32_t start, uint32_t length) {
   if (length == 0 || start >= kBufferSize) {
     return;
   }
@@ -263,7 +262,7 @@ void SharedMemory::RangeWrittenByGpu(uint32_t start, uint32_t length,
 
   // Mark the range as valid (so pages are not reuploaded until modified by the
   // CPU) and watch it so the CPU can reuse it and this will be caught.
-  MakeRangeValid(start, length, true, is_resolve);
+  MakeRangeValid(start, length, true);
 }
 
 bool SharedMemory::AllocateSparseHostGpuMemoryRange(
@@ -275,9 +274,7 @@ bool SharedMemory::AllocateSparseHostGpuMemoryRange(
 }
 
 void SharedMemory::MakeRangeValid(uint32_t start, uint32_t length,
-                                  bool written_by_gpu,
-                                  bool written_by_gpu_resolve) {
-  assert_false(written_by_gpu_resolve && !written_by_gpu);
+                                  bool written_by_gpu) {
   if (length == 0 || start >= kBufferSize) {
     return;
   }
@@ -305,11 +302,6 @@ void SharedMemory::MakeRangeValid(uint32_t start, uint32_t length,
         block.valid_and_gpu_written |= valid_bits;
       } else {
         block.valid_and_gpu_written &= ~valid_bits;
-      }
-      if (written_by_gpu_resolve) {
-        block.valid_and_gpu_resolved |= valid_bits;
-      } else {
-        block.valid_and_gpu_resolved &= ~valid_bits;
       }
     }
   }
@@ -345,13 +337,9 @@ void SharedMemory::UnlinkWatchRange(WatchRange* range) {
   watch_range_first_free_ = range;
 }
 
-bool SharedMemory::RequestRange(uint32_t start, uint32_t length,
-                                bool* any_data_resolved_out) {
+bool SharedMemory::RequestRange(uint32_t start, uint32_t length) {
   if (!length) {
     // Some texture or buffer is empty, for example - safe to draw in this case.
-    if (any_data_resolved_out) {
-      *any_data_resolved_out = false;
-    }
     return true;
   }
   if (start > kBufferSize || (kBufferSize - start) < length) {
@@ -368,7 +356,6 @@ bool SharedMemory::RequestRange(uint32_t start, uint32_t length,
   uint32_t page_last = (start + length - 1) >> page_size_log2_;
 
   upload_ranges_.clear();
-  bool any_data_resolved = false;
   uint32_t block_first = page_first >> 6;
   uint32_t block_last = page_last >> 6;
   uint32_t range_start = UINT32_MAX;
@@ -377,20 +364,14 @@ bool SharedMemory::RequestRange(uint32_t start, uint32_t length,
     for (uint32_t i = block_first; i <= block_last; ++i) {
       const SystemPageFlagsBlock& block = system_page_flags_[i];
       uint64_t block_valid = block.valid;
-      uint64_t block_resolved = block.valid_and_gpu_resolved;
       // Consider pages in the block outside the requested range valid.
       if (i == block_first) {
         uint64_t block_before = (uint64_t(1) << (page_first & 63)) - 1;
         block_valid |= block_before;
-        block_resolved &= ~block_before;
       }
       if (i == block_last && (page_last & 63) != 63) {
         uint64_t block_inside = (uint64_t(1) << ((page_last & 63) + 1)) - 1;
         block_valid |= ~block_inside;
-        block_resolved &= block_inside;
-      }
-      if (block_resolved) {
-        any_data_resolved = true;
       }
 
       while (true) {
@@ -425,9 +406,6 @@ bool SharedMemory::RequestRange(uint32_t start, uint32_t length,
   if (range_start != UINT32_MAX) {
     upload_ranges_.push_back(
         std::make_pair(range_start, page_last + 1 - range_start));
-  }
-  if (any_data_resolved_out) {
-    *any_data_resolved_out = any_data_resolved;
   }
   if (upload_ranges_.empty()) {
     return true;
@@ -494,7 +472,6 @@ std::pair<uint32_t, uint32_t> SharedMemory::MemoryInvalidationCallback(
     SystemPageFlagsBlock& block = system_page_flags_[i];
     block.valid &= ~invalidate_bits;
     block.valid_and_gpu_written &= ~invalidate_bits;
-    block.valid_and_gpu_resolved &= ~invalidate_bits;
   }
 
   FireWatches(page_first, page_last, false);

--- a/src/graphics/vulkan/command_processor.cpp
+++ b/src/graphics/vulkan/command_processor.cpp
@@ -2608,7 +2608,7 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type,
   // Invalidate textures in memexported memory and watch for changes.
   for (const draw_util::MemExportRange& memexport_range : memexport_ranges_) {
     shared_memory_->RangeWrittenByGpu(memexport_range.base_address_dwords << 2,
-                                      memexport_range.size_bytes, false);
+                                      memexport_range.size_bytes);
   }
 
   return true;

--- a/src/graphics/vulkan/shared_memory.cpp
+++ b/src/graphics/vulkan/shared_memory.cpp
@@ -408,7 +408,7 @@ bool VulkanSharedMemory::UploadRanges(
         break;
       }
       MakeRangeValid(upload_range_start << page_size_log2(),
-                     uint32_t(upload_buffer_size), false, false);
+                     uint32_t(upload_buffer_size), false);
       std::memcpy(
           upload_buffer_mapping,
           memory().TranslatePhysical(upload_range_start << page_size_log2()),


### PR DESCRIPTION
Replace incorrect host sRGB approximation of Xbox 360 piecewise linear (PWL) gamma with `R16G16B16A16_UNORM` storage for `k_8_8_8_8_GAMMA` render targets, enabling correct linear-space blending.

Shared memory + texture cache cleanup:
- Remove resolve tracking (`valid_and_gpu_resolved`) from `SharedMemory`
- Remove resolve tracking from `TextureCache`, rename `IsActiveTextureResolved` to `IsActiveTextureResolutionScaled`
- Update command processor callers for new signatures

 Flag renames + base gpu changes:
- Rename cvar `gamma_render_target_as_srgb` to `gamma_render_target_as_unorm16`
- Remove sRGB constants and gamma tracking from base `RenderTargetCache`
- Add `sGammaFormatHostStorageSeparate()` virtual for backend override
- Make `PWLGammaToLinear`/`PreSaturatedLinearToPWLGamma` public static with explicit `dxbc::Assembler&` parameter
- Rename `textures_resolved` to `textures_resolution_scaled` in DXBC translator
- Remove sRGB texture sampling path from fetch translator
- Invert gamma flag semantics in pipeline cache and OM translator

D3D12 render target format + transfer shaders:
- Change `k_8_8_8_8_GAMMA` resource format from `R8G8B8A8_TYPELESS` to `R16G16B16A16_UNORM` in D3D12 backend
- Remove sRGB draw descriptors and command list sRGB tracking
- Add PWL gamma conversion at EDRAM transfer boundaries (64bpp packing, 32bpp stencil/depth/color paths, output unpacking)
- Add gamma conversion in dump pipeline and clear values
- Update Vulkan backend for compilation (minimal, no UNorm16 yet)

Based on Xenia commits [cec9ca0ef](https://github.com/xenia-project/xenia/commit/cec9ca0ef2f1343070e6211478db37d4b4a8ad95), [0a19234b4](https://github.com/xenia-project/xenia/commit/0a19234b4e6905f2cd249b4af6172ca4656c92de), [c7f61342d](https://github.com/xenia-project/xenia/commit/c7f61342d7061b8264e4b988b8d2e03351b6e088)