### PR TITLE
Fix Truncation and Tail Call Issues in Jump Tables for Codegen

### DIFF
--- a/src/codegen/builders/control_flow.cpp
+++ b/src/codegen/builders/control_flow.cpp
@@ -126,6 +126,13 @@ bool build_bctr(BuilderContext& ctx) {
       ctx.println("\tcase {}:", i);
       auto label = jt->targets[i];
 
+      // TODO(tomc): Figure out if this actually is triggered on real hardware and what would
+      // happen?
+      if (label == 0) {
+        ctx.println("\t\t__builtin_trap(); // ERROR - detected jump to null value");
+        continue;
+      }
+
       auto kind = ctx.graph().classifyTarget(label, ctx.base, false);
       switch (kind) {
         case TargetKind::InternalLabel:
@@ -139,16 +146,17 @@ bool build_bctr(BuilderContext& ctx) {
             REXCODEGEN_ERROR(
                 "Jump target 0x{:08X} classified as function but not in graph at bctr 0x{:08X}",
                 label, ctx.base);
-            ctx.println("\t\tREX_FATAL(\"Jump target 0x{:08X} classified as function but not "
-                        "in graph at bctr 0x{:08X}\");",
-                        label, ctx.base);
+            ctx.println(
+                "\t\tREX_FATAL(\"Jump target 0x{:08X} classified as function but not "
+                "in graph at bctr 0x{:08X}\");",
+                label, ctx.base);
           }
           ctx.println("\t\treturn;");
           break;
         default:
           REXCODEGEN_ERROR("Jump target 0x{:08X} unresolved at bctr 0x{:08X}", label, ctx.base);
-          ctx.println("\t\tREX_FATAL(\"Jump target 0x{:08X} unresolved at bctr 0x{:08X}\");",
-                      label, ctx.base);
+          ctx.println("\t\tREX_FATAL(\"Jump target 0x{:08X} unresolved at bctr 0x{:08X}\");", label,
+                      ctx.base);
           break;
       }
     }

--- a/src/codegen/discovery.cpp
+++ b/src/codegen/discovery.cpp
@@ -560,6 +560,18 @@ std::optional<JumpTable> detectJumpTable(DecodedBinary& decoded, uint32_t bctrAd
     // Validate target is within code region - jump table targets help DEFINE function extent
     // Don't constrain by funcEnd since that's just PDATA which may not include out-of-line code
     if (target == 0 || !containingRegion.contains(target)) {
+      // TODO(tomc): Figure out what this voodoo does on real hardware. Its a jump target that
+      // points to a null value..?
+      if (target != 0) {
+        auto outsideInsn = decoded.read<uint32_t>(target);
+        if (outsideInsn && (*outsideInsn == 0x00000000 || *outsideInsn == 0xFFFFFFFF)) {
+          REXCODEGEN_TRACE(
+              "detectJumpTable: bctr=0x{:08X} entry[{}] target=0x{:08X} null jump sentinel",
+              bctrAddr, i, target);
+          jt.targets.push_back(0);  // sentinel
+          continue;
+        }
+      }
       // End of valid entries
       REXCODEGEN_TRACE(
           "detectJumpTable: bctr=0x{:08X} entry[{}] target=0x{:08X} invalid (region "


### PR DESCRIPTION
## Summary

- Fix null-jump sentinel handling in jump table detection.
  - entries pointing to null padding at code region boundaries no longer truncate the table early
- Fix `build_bctr` to use direct graph lookup instead of `emit_function_call` for jump table targets and emit `REX_FATAL` for unresolved targets.

The **old** jump table detector used `containingRegion.contains()` with an exclusive end bound. When a jump table entry pointed exactly to the region boundary (null padding between code sections), it was rejected and all subsequent valid entries were lost. 

This caused two NG2 switch tables to be truncated. #169

The fix treats entries pointing to null dwords outside the region as sentinels (stored as 0), continues reading, and emits `__builtin_trap()` in codegen for those cases. **TODO: Figure out what these are and why they exist?**

Separately, `build_bctr` was fixed to look up function targets directly via `graph().getFunction()` instead of `emit_function_call()`, which requires a CallEdge that doesn't exist for bctr sites.