### PR TITLE
remove implemented stub

### DIFF
--- a/src/kernel/xam/xam_misc.cpp
+++ b/src/kernel/xam/xam_misc.cpp
@@ -395,7 +395,6 @@ XAM_EXPORT_STUB(__imp__XamDataCenterGetDhcpOptionResponseHostnameAndPort);
 XAM_EXPORT_STUB(__imp__XamDataCenterLog);
 XAM_EXPORT_STUB(__imp__XamDataCenterLogEvent);
 XAM_EXPORT_STUB(__imp__XamDataCenterShowForceSignInMessage);
-XAM_EXPORT_STUB(__imp__XamDbgPrint);
 XAM_EXPORT_STUB(__imp__XamDbgSetBreakLevel);
 XAM_EXPORT_STUB(__imp__XamDbgSetOutputLevel);
 XAM_EXPORT_STUB(__imp__XamDeactivateCounterMeasure);


### PR DESCRIPTION
This stub is defined in xboxkrnl_strings.cpp, removing it fixes the following compile issue

<img width="3002" height="264" alt="image" src="https://github.com/user-attachments/assets/de2183a5-cd37-46de-94cd-cbd4058a70ab" />
