### PR TITLE
Implement vavgsw instruction

### DIFF
--- a/include/rex/ppc/memory.h
+++ b/include/rex/ppc/memory.h
@@ -360,6 +360,13 @@ inline simde__m128i simde_mm_avg_epi16(simde__m128i a, simde__m128i b) {
                             simde_mm_avg_epu16(simde_mm_xor_si128(c, a), simde_mm_xor_si128(c, b)));
 }
 
+// Signed 32-bit average
+inline simde__m128i simde_mm_avg_epi32(simde__m128i a, simde__m128i b) {
+  simde__m128i sum = simde_mm_add_epi32(simde_mm_srai_epi32(a, 1), simde_mm_srai_epi32(b, 1));
+  return simde_mm_add_epi32(sum,
+                            simde_mm_and_si128(simde_mm_or_si128(a, b), simde_mm_set1_epi32(1)));
+}
+
 // Convert unsigned 32-bit integers to floats
 inline simde__m128 simde_mm_cvtepu32_ps_(simde__m128i src1) {
   simde__m128i xmm1 = simde_mm_add_epi32(src1, simde_mm_set1_epi32(127));

--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -477,6 +477,7 @@ bool build_vminub(BuilderContext& ctx);
 // Vector average
 bool build_vavgsb(BuilderContext& ctx);
 bool build_vavgsh(BuilderContext& ctx);
+bool build_vavgsw(BuilderContext& ctx);
 bool build_vavgub(BuilderContext& ctx);
 bool build_vavguh(BuilderContext& ctx);
 

--- a/src/codegen/builders/vector.cpp
+++ b/src/codegen/builders/vector.cpp
@@ -433,6 +433,16 @@ bool build_vavgsh(BuilderContext& ctx) {
   return true;
 }
 
+bool build_vavgsw(BuilderContext& ctx) {
+  ctx.println(
+      "\tsimde_mm_store_si128((simde__m128i*){}.s32, "
+      "rex::simde_mm_avg_epi32("
+      "simde_mm_load_si128((simde__m128i*){}.s32), "
+      "simde_mm_load_si128((simde__m128i*){}.s32)));",
+      ctx.v(ctx.insn.operands[0]), ctx.v(ctx.insn.operands[1]), ctx.v(ctx.insn.operands[2]));
+  return true;
+}
+
 bool build_vavgub(BuilderContext& ctx) {
   ctx.emit_vec_int_binary("avg_epu8", "u8");
   return true;

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -468,6 +468,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable() {
       //=====================================================================
       {PPC_INST_VAVGSB, build_vavgsb},
       {PPC_INST_VAVGSH, build_vavgsh},
+      {PPC_INST_VAVGSW, build_vavgsw},
       {PPC_INST_VAVGUB, build_vavgub},
       {PPC_INST_VAVGUH, build_vavguh},
 


### PR DESCRIPTION
Implement vavgsw (Vector Average Signed Word) instruction, and rex::simde_mm_avg_epi32 helper.