### PR TITLE
Fix: POSIX async threading, POSIX memory fixes.

### DIFF
--- a/src/core/mapped_memory_posix.cpp
+++ b/src/core/mapped_memory_posix.cpp
@@ -10,6 +10,9 @@
  */
 
 #include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -17,15 +20,17 @@
 #include <unistd.h>
 
 #include <rex/filesystem.h>
+#include <rex/math.h>
 #include <rex/memory/mapped_memory.h>
+#include <rex/memory/utils.h>
 #include <rex/platform.h>
 
 namespace rex::memory {
 
 class PosixMappedMemory : public MappedMemory {
  public:
-  PosixMappedMemory(void* data, size_t size, int file_descriptor)
-      : MappedMemory(data, size), file_descriptor_(file_descriptor) {}
+  PosixMappedMemory(void* data, size_t size, int file_descriptor, int protection)
+      : MappedMemory(data, size), file_descriptor_(file_descriptor), protection_(protection) {}
 
   ~PosixMappedMemory() override {
     if (data_) {
@@ -39,6 +44,8 @@ class PosixMappedMemory : public MappedMemory {
   static std::unique_ptr<PosixMappedMemory> WrapFileDescriptor(int file_descriptor, Mode mode,
                                                                size_t offset = 0,
                                                                size_t length = 0) {
+    const size_t aligned_offset = offset & ~(memory::allocation_granularity() - 1);
+    const size_t offset_in_mapping = offset - aligned_offset;
     int protection = 0;
     switch (mode) {
       case Mode::kRead:
@@ -49,23 +56,30 @@ class PosixMappedMemory : public MappedMemory {
         break;
     }
 
-    size_t map_length = length;
-    if (!length) {
-      struct stat64 file_stat;
-      if (fstat64(file_descriptor, &file_stat)) {
-        close(file_descriptor);
-        return nullptr;
-      }
-      map_length = size_t(file_stat.st_size);
+    struct stat64 file_stat;
+    if (fstat64(file_descriptor, &file_stat)) {
+      close(file_descriptor);
+      return nullptr;
+    }
+    const size_t file_size = size_t(file_stat.st_size);
+    if (aligned_offset > file_size) {
+      close(file_descriptor);
+      return nullptr;
     }
 
-    void* data = mmap(0, map_length, protection, MAP_SHARED, file_descriptor, offset);
+    size_t map_length = length ? (length + offset_in_mapping) : (file_size - aligned_offset);
+    if (!map_length) {
+      close(file_descriptor);
+      return nullptr;
+    }
+
+    void* data = mmap(0, map_length, protection, MAP_SHARED, file_descriptor, aligned_offset);
     if (!data || data == MAP_FAILED) {
       close(file_descriptor);
       return nullptr;
     }
 
-    return std::make_unique<PosixMappedMemory>(data, map_length, file_descriptor);
+    return std::make_unique<PosixMappedMemory>(data, map_length, file_descriptor, protection);
   }
 
   void Close(uint64_t truncate_size) override {
@@ -84,8 +98,48 @@ class PosixMappedMemory : public MappedMemory {
 
   void Flush() override { msync(data(), size(), MS_ASYNC); }
 
+  bool Remap(size_t offset, size_t length) override {
+    if (file_descriptor_ < 0) {
+      return false;
+    }
+
+    const size_t aligned_offset = offset & ~(memory::allocation_granularity() - 1);
+    const size_t offset_in_mapping = offset - aligned_offset;
+
+    struct stat64 file_stat;
+    if (fstat64(file_descriptor_, &file_stat)) {
+      return false;
+    }
+    const size_t file_size = size_t(file_stat.st_size);
+    if (aligned_offset > file_size) {
+      return false;
+    }
+
+    size_t map_length = length ? (length + offset_in_mapping) : (file_size - aligned_offset);
+    if (!map_length) {
+      return false;
+    }
+
+    if (data_) {
+      munmap(data_, size());
+      data_ = nullptr;
+      size_ = 0;
+    }
+
+    void* remapped =
+        mmap(nullptr, map_length, protection_, MAP_SHARED, file_descriptor_, aligned_offset);
+    if (!remapped || remapped == MAP_FAILED) {
+      return false;
+    }
+
+    data_ = remapped;
+    size_ = map_length;
+    return true;
+  }
+
  private:
   int file_descriptor_;
+  int protection_;
 };
 
 std::unique_ptr<MappedMemory> MappedMemory::Open(const std::filesystem::path& path, Mode mode,
@@ -127,10 +181,136 @@ std::unique_ptr<MappedMemory> MappedMemory::OpenForAndroidContentUri(const std::
 }
 #endif  // REX_PLATFORM_ANDROID
 
+class PosixChunkedMappedMemoryWriter : public ChunkedMappedMemoryWriter {
+ public:
+  PosixChunkedMappedMemoryWriter(const std::filesystem::path& path, size_t chunk_size,
+                                 bool low_address_space)
+      : ChunkedMappedMemoryWriter(path, chunk_size, low_address_space) {}
+
+  ~PosixChunkedMappedMemoryWriter() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    chunks_.clear();
+  }
+
+  uint8_t* Allocate(size_t length) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!chunks_.empty()) {
+      uint8_t* result = chunks_.back()->Allocate(length);
+      if (result) {
+        return result;
+      }
+    }
+    auto chunk = std::make_unique<Chunk>(chunk_size_);
+    std::filesystem::path chunk_path = path_;
+    chunk_path.replace_extension(std::string(".") + std::to_string(chunks_.size()));
+    if (!chunk->Open(chunk_path, low_address_space_)) {
+      return nullptr;
+    }
+    uint8_t* result = chunk->Allocate(length);
+    chunks_.push_back(std::move(chunk));
+    return result;
+  }
+
+  void Flush() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& chunk : chunks_) {
+      chunk->Flush();
+    }
+  }
+
+  void FlushNew() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& chunk : chunks_) {
+      chunk->FlushNew();
+    }
+  }
+
+ private:
+  class Chunk {
+   public:
+    explicit Chunk(size_t capacity)
+        : file_descriptor_(-1),
+          data_(nullptr),
+          offset_(0),
+          capacity_(capacity),
+          last_flush_offset_(0) {}
+
+    ~Chunk() {
+      if (data_) {
+        munmap(data_, capacity_);
+      }
+      if (file_descriptor_ >= 0) {
+        close(file_descriptor_);
+      }
+    }
+
+    bool Open(const std::filesystem::path& path, bool low_address_space) {
+      file_descriptor_ = open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0666);
+      if (file_descriptor_ < 0) {
+        return false;
+      }
+      if (ftruncate64(file_descriptor_, static_cast<off64_t>(capacity_)) != 0) {
+        return false;
+      }
+
+      int flags = MAP_SHARED;
+#if REX_PLATFORM_LINUX && defined(__x86_64__) && defined(MAP_32BIT)
+      if (low_address_space) {
+        flags |= MAP_32BIT;
+      }
+#else
+      (void)low_address_space;
+#endif
+
+      data_ = static_cast<uint8_t*>(
+          mmap(nullptr, capacity_, PROT_READ | PROT_WRITE, flags, file_descriptor_, 0));
+      if (!data_ || data_ == MAP_FAILED) {
+        data_ = nullptr;
+        return false;
+      }
+
+      return true;
+    }
+
+    uint8_t* Allocate(size_t length) {
+      if (capacity_ - offset_ < length) {
+        return nullptr;
+      }
+      uint8_t* result = data_ + offset_;
+      offset_ += length;
+      return result;
+    }
+
+    void Flush() {
+      if (offset_) {
+        msync(data_, offset_, MS_ASYNC);
+      }
+    }
+
+    void FlushNew() {
+      if (offset_ > last_flush_offset_) {
+        msync(data_ + last_flush_offset_, offset_ - last_flush_offset_, MS_ASYNC);
+        last_flush_offset_ = offset_;
+      }
+    }
+
+   private:
+    int file_descriptor_;
+    uint8_t* data_;
+    size_t offset_;
+    size_t capacity_;
+    size_t last_flush_offset_;
+  };
+
+  std::mutex mutex_;
+  std::vector<std::unique_ptr<Chunk>> chunks_;
+};
+
 std::unique_ptr<ChunkedMappedMemoryWriter> ChunkedMappedMemoryWriter::Open(
     const std::filesystem::path& path, size_t chunk_size, bool low_address_space) {
-  // TODO: Implement if needed
-  return nullptr;
+  size_t aligned_chunk_size = rex::round_up(chunk_size, memory::allocation_granularity());
+  return std::make_unique<PosixChunkedMappedMemoryWriter>(path, aligned_chunk_size,
+                                                          low_address_space);
 }
 
 }  // namespace rex::memory

--- a/src/core/memory_posix.cpp
+++ b/src/core/memory_posix.cpp
@@ -13,8 +13,8 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
-#include <fstream>
 #include <string>
+#include <vector>
 
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -82,10 +82,19 @@ void AndroidShutdown() {
 #endif
 
 size_t page_size() {
-  return getpagesize();
+  static const size_t value = []() -> size_t {
+    long sysconf_page_size = sysconf(_SC_PAGESIZE);
+    if (sysconf_page_size > 0) {
+      return static_cast<size_t>(sysconf_page_size);
+    }
+    return static_cast<size_t>(getpagesize());
+  }();
+  return value;
 }
 size_t allocation_granularity() {
-  return page_size();
+  // Mirrors current POSIX behavior where granularity equals page size.
+  static const size_t value = page_size();
+  return value;
 }
 
 uint32_t ToPosixProtectFlags(PageAccess access) {
@@ -110,6 +119,28 @@ bool IsWritableExecutableMemorySupported() {
   return true;
 }
 
+namespace {
+
+static bool AlignRangeToPageBounds(void* base_address, size_t length, void*& aligned_base_address,
+                                   size_t& aligned_length) {
+  if (!base_address || !length) {
+    return false;
+  }
+  const uintptr_t page = page_size();
+  const uintptr_t addr = reinterpret_cast<uintptr_t>(base_address);
+  const uintptr_t start = addr & ~(page - 1);
+  const uintptr_t end_unaligned = addr + length;
+  if (end_unaligned < addr) {
+    return false;
+  }
+  const uintptr_t end = rex::round_up(end_unaligned, page);
+  aligned_base_address = reinterpret_cast<void*>(start);
+  aligned_length = static_cast<size_t>(end - start);
+  return aligned_length != 0;
+}
+
+}  // namespace
+
 // TODO(tomc): this needs to go somewhere else. we should utilize the platform namespace more.
 #if REX_PLATFORM_LINUX
 namespace {
@@ -120,12 +151,12 @@ struct LinuxMapEntry {
   char perms[5] = {};
 };
 
-// Parse a line from /proc/self/maps into a LinuxMapEntry
-static bool ParseProcMapsLine(const std::string& line, LinuxMapEntry& out) {
+// Parse a line from /proc/self/maps into a LinuxMapEntry.
+static bool ParseProcMapsLine(const char* line, LinuxMapEntry& out) {
   out = LinuxMapEntry{};
   unsigned long long start = 0, end = 0;
   char perms[5] = {};
-  const int matched = std::sscanf(line.c_str(), "%llx-%llx %4s", &start, &end, perms);
+  const int matched = std::sscanf(line, "%llx-%llx %4s", &start, &end, perms);
   if (matched < 3)
     return false;
   out.start = static_cast<uintptr_t>(start);
@@ -134,23 +165,31 @@ static bool ParseProcMapsLine(const std::string& line, LinuxMapEntry& out) {
   return out.start < out.end;
 }
 
-// Find the mapping entry in /proc/self/maps that contains the given address
-static bool FindEntryForAddress(void* address, LinuxMapEntry& out_entry) {
-  const uintptr_t addr = reinterpret_cast<uintptr_t>(address);
-  std::ifstream maps("/proc/self/maps");
-  if (!maps.is_open())
+static std::vector<LinuxMapEntry>& GetMapsScratch() {
+  thread_local std::vector<LinuxMapEntry> entries;
+  return entries;
+}
+
+static bool ReadProcMaps(std::vector<LinuxMapEntry>& out_entries) {
+  out_entries.clear();
+  if (out_entries.capacity() < 2048) {
+    out_entries.reserve(2048);
+  }
+
+  FILE* maps = std::fopen("/proc/self/maps", "r");
+  if (!maps) {
     return false;
-  std::string line;
-  while (std::getline(maps, line)) {
-    LinuxMapEntry e;
-    if (!ParseProcMapsLine(line, e))
-      continue;
-    if (addr >= e.start && addr < e.end) {
-      out_entry = e;
-      return true;
+  }
+
+  char line[512];
+  while (std::fgets(line, sizeof(line), maps)) {
+    LinuxMapEntry entry;
+    if (ParseProcMapsLine(line, entry)) {
+      out_entries.push_back(entry);
     }
   }
-  return false;
+  std::fclose(maps);
+  return !out_entries.empty();
 }
 
 // Check if [base, base+length) is fully covered by existing mappings (no gaps)
@@ -164,23 +203,22 @@ static bool IsRangeFullyMapped(void* base_address, size_t length) {
     return false;
   }
 
-  std::ifstream maps("/proc/self/maps");
-  if (!maps.is_open())
+  auto& entries = GetMapsScratch();
+  if (!ReadProcMaps(entries)) {
     return false;
-
+  }
   uintptr_t cursor = begin;
-  std::string line;
-  while (std::getline(maps, line)) {
-    LinuxMapEntry e;
-    if (!ParseProcMapsLine(line, e))
+  for (const LinuxMapEntry& entry : entries) {
+    if (entry.end <= cursor) {
       continue;
-    if (e.end <= cursor)
-      continue;
-    if (e.start > cursor)
+    }
+    if (entry.start > cursor) {
       return false;  // gap found
-    cursor = e.end;
-    if (cursor >= end)
+    }
+    cursor = entry.end;
+    if (cursor >= end) {
       return true;
+    }
   }
   return cursor >= end;
 }
@@ -196,6 +234,49 @@ static PageAccess PermsToPageAccess(const char perms[5]) {
   if (x)
     return w ? PageAccess::kExecuteReadWrite : PageAccess::kExecuteReadOnly;
   return w ? PageAccess::kReadWrite : PageAccess::kReadOnly;
+}
+
+static bool FindRegionForAddress(void* address, uintptr_t& out_region_start,
+                                 uintptr_t& out_region_end, PageAccess& out_access) {
+  const uintptr_t addr = reinterpret_cast<uintptr_t>(address);
+  auto& entries = GetMapsScratch();
+  if (!ReadProcMaps(entries)) {
+    return false;
+  }
+
+  size_t found_index = size_t(-1);
+  for (size_t i = 0; i < entries.size(); ++i) {
+    if (addr >= entries[i].start && addr < entries[i].end) {
+      found_index = i;
+      break;
+    }
+  }
+  if (found_index == size_t(-1)) {
+    return false;
+  }
+
+  out_access = PermsToPageAccess(entries[found_index].perms);
+  out_region_start = entries[found_index].start;
+  out_region_end = entries[found_index].end;
+
+  for (size_t i = found_index; i > 0; --i) {
+    const auto& prev = entries[i - 1];
+    const auto& cur = entries[i];
+    if (prev.end != cur.start || PermsToPageAccess(prev.perms) != out_access) {
+      break;
+    }
+    out_region_start = prev.start;
+  }
+  for (size_t i = found_index + 1; i < entries.size(); ++i) {
+    const auto& prev = entries[i - 1];
+    const auto& cur = entries[i];
+    if (prev.end != cur.start || PermsToPageAccess(cur.perms) != out_access) {
+      break;
+    }
+    out_region_end = cur.end;
+  }
+
+  return true;
 }
 
 }  // namespace
@@ -259,12 +340,17 @@ void* AllocFixed(void* base_address, size_t length, AllocationType allocation_ty
 bool DeallocFixed(void* base_address, size_t length, DeallocationType deallocation_type) {
   switch (deallocation_type) {
     case DeallocationType::kDecommit: {
+      void* aligned_base_address = nullptr;
+      size_t aligned_length = 0;
+      if (!AlignRangeToPageBounds(base_address, length, aligned_base_address, aligned_length)) {
+        return false;
+      }
       // Decommit: remove access first, then release physical pages
-      if (mprotect(base_address, length, PROT_NONE) != 0) {
+      if (mprotect(aligned_base_address, aligned_length, PROT_NONE) != 0) {
         return false;
       }
 #if defined(MADV_DONTNEED)
-      (void)madvise(base_address, length, MADV_DONTNEED);
+      (void)madvise(aligned_base_address, aligned_length, MADV_DONTNEED);
 #endif
       return true;
     }
@@ -283,6 +369,12 @@ bool Protect(void* base_address, size_t length, PageAccess access, PageAccess* o
     *out_old_access = PageAccess::kNoAccess;
   }
 
+  void* aligned_base_address = nullptr;
+  size_t aligned_length = 0;
+  if (!AlignRangeToPageBounds(base_address, length, aligned_base_address, aligned_length)) {
+    return false;
+  }
+
 #if REX_PLATFORM_LINUX
   // NOTE(tomc): we may want to look at doing this differently. it should work for now
   //             but there is a TOCTOU window between reading and changing.
@@ -290,15 +382,17 @@ bool Protect(void* base_address, size_t length, PageAccess access, PageAccess* o
   //             atomic in a mutli-threaded process either, but it's something to be aware of.
   // Query old access before changing, if the caller needs it
   if (out_old_access) {
-    LinuxMapEntry e;
-    if (FindEntryForAddress(base_address, e)) {
-      *out_old_access = PermsToPageAccess(e.perms);
+    uintptr_t region_start = 0;
+    uintptr_t region_end = 0;
+    PageAccess region_access = PageAccess::kNoAccess;
+    if (FindRegionForAddress(aligned_base_address, region_start, region_end, region_access)) {
+      *out_old_access = region_access;
     }
   }
 #endif
 
   uint32_t prot = ToPosixProtectFlags(access);
-  return mprotect(base_address, length, prot) == 0;
+  return mprotect(aligned_base_address, aligned_length, prot) == 0;
 }
 
 bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
@@ -310,14 +404,13 @@ bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
   access_out = PageAccess::kNoAccess;
   length = 0;
 
-  LinuxMapEntry e;
-  if (!FindEntryForAddress(base_address, e)) {
+  uintptr_t region_start = 0;
+  uintptr_t region_end = 0;
+  if (!FindRegionForAddress(base_address, region_start, region_end, access_out)) {
     return false;
   }
 
-  const uintptr_t addr = reinterpret_cast<uintptr_t>(base_address);
-  length = static_cast<size_t>(e.end - addr);
-  access_out = PermsToPageAccess(e.perms);
+  length = static_cast<size_t>(region_end - region_start);
 
   return true;
 #endif
@@ -349,30 +442,18 @@ FileMappingHandle CreateFileMappingHandle(const std::filesystem::path& path, siz
   }
   return static_cast<FileMappingHandle>(ashmem_fd);
 #else
-  int oflag;
-  switch (access) {
-    case PageAccess::kNoAccess:
-      oflag = 0;
-      break;
-    case PageAccess::kReadOnly:
-    case PageAccess::kExecuteReadOnly:
-      oflag = O_RDONLY;
-      break;
-    case PageAccess::kReadWrite:
-    case PageAccess::kExecuteReadWrite:
-      oflag = O_RDWR;
-      break;
-    default:
-      assert_always();
-      return kFileMappingHandleInvalid;
-  }
-  oflag |= O_CREAT;
+  (void)access;
+  (void)commit;
+  int oflag = O_CREAT | O_RDWR;
   auto full_path = MakeShmName(path);
   int ret = shm_open(full_path.c_str(), oflag, 0777);
   if (ret < 0) {
     return kFileMappingHandleInvalid;
   }
-  if (ftruncate64(ret, static_cast<off_t>(length)) != 0) {
+  // Windows rounds mapping object size to page granularity internally.
+  // Do the same on POSIX to preserve cross-platform map range behavior.
+  const size_t aligned_length = rex::round_up(length, page_size());
+  if (aligned_length < length || ftruncate64(ret, static_cast<off_t>(aligned_length)) != 0) {
     close(ret);
     shm_unlink(full_path.c_str());
     return kFileMappingHandleInvalid;
@@ -396,6 +477,16 @@ void* MapFileView(FileMappingHandle handle, void* base_address, size_t length, P
   if (file_offset % page != 0) {
     return nullptr;
   }
+  const int fd = static_cast<int>(handle);
+  struct stat64 file_stat;
+  if (fstat64(fd, &file_stat) != 0) {
+    return nullptr;
+  }
+  const uint64_t mapped_size = uint64_t(rex::round_up(size_t(file_stat.st_size), page));
+  const uint64_t mapping_end = uint64_t(file_offset) + uint64_t(length);
+  if (mapping_end < file_offset || mapping_end > mapped_size) {
+    return nullptr;
+  }
 
   int flags = MAP_SHARED;
 
@@ -407,8 +498,7 @@ void* MapFileView(FileMappingHandle handle, void* base_address, size_t length, P
   }
 
   uint32_t prot = ToPosixProtectFlags(access);
-  void* result = mmap64(base_address, length, prot, flags, static_cast<int>(handle),
-                        static_cast<off_t>(file_offset));
+  void* result = mmap64(base_address, length, prot, flags, fd, static_cast<off_t>(file_offset));
   if (result == MAP_FAILED) {
     return nullptr;
   }
@@ -423,6 +513,7 @@ void* MapFileView(FileMappingHandle handle, void* base_address, size_t length, P
 }
 
 bool UnmapFileView(FileMappingHandle handle, void* base_address, size_t length) {
+  (void)handle;
   return munmap(base_address, length) == 0;
 }
 

--- a/src/core/threading_posix.cpp
+++ b/src/core/threading_posix.cpp
@@ -14,8 +14,10 @@ static_assert(REX_PLATFORM_LINUX || REX_PLATFORM_MAC, "This file is POSIX-only")
 #include <signal.h>
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <ctime>
+#include <deque>
 #include <memory>
 
 #include <pthread.h>
@@ -163,12 +165,6 @@ void Sleep(std::chrono::microseconds duration) {
 
 // TODO(bwrsandman) Implement by allowing alert interrupts from IO operations
 thread_local bool alertable_state_ = false;
-SleepResult AlertableSleep(std::chrono::microseconds duration) {
-  alertable_state_ = true;
-  Sleep(duration);
-  alertable_state_ = false;
-  return SleepResult::kSuccess;
-}
 
 TlsHandle AllocateTlsHandle() {
   auto key = static_cast<pthread_key_t>(-1);
@@ -217,7 +213,34 @@ class PosixConditionBase {
     }
   }
 
-  static std::pair<WaitResult, size_t> WaitMultiple(std::vector<PosixConditionBase*>&& handles,
+  WaitResult WaitAlertable(const std::function<bool()>& alertable_predicate,
+                           std::chrono::milliseconds timeout) {
+    bool executed;
+    auto predicate = [this, &alertable_predicate] {
+      return this->signaled() || alertable_predicate();
+    };
+    auto lock = std::unique_lock<std::mutex>(mutex_);
+    if (predicate()) {
+      executed = true;
+    } else {
+      if (timeout == std::chrono::milliseconds::max()) {
+        cond_.wait(lock, predicate);
+        executed = true;  // Did not time out;
+      } else {
+        executed = cond_.wait_for(lock, timeout, predicate);
+      }
+    }
+    if (!executed) {
+      return WaitResult::kTimeout;
+    }
+    if (alertable_predicate()) {
+      return WaitResult::kUserCallback;
+    }
+    post_execution();
+    return WaitResult::kSuccess;
+  }
+
+  static std::pair<WaitResult, size_t> WaitMultiple(const std::vector<PosixConditionBase*>& handles,
                                                     bool wait_all,
                                                     std::chrono::milliseconds timeout) {
     assert_true(handles.size() > 0);
@@ -265,6 +288,63 @@ class PosixConditionBase {
     } else {
       return std::make_pair<WaitResult, size_t>(WaitResult::kTimeout, 0);
     }
+  }
+
+  static std::pair<WaitResult, size_t> WaitMultipleAlertable(
+      const std::vector<PosixConditionBase*>& handles, bool wait_all,
+      std::chrono::milliseconds timeout, const std::function<bool()>& alertable_predicate) {
+    assert_true(handles.size() > 0);
+
+    std::function<bool()> wait_predicate;
+    {
+      using iter_t = std::vector<PosixConditionBase*>::const_iterator;
+      const auto signal_predicate = [](auto h) { return h->signaled(); };
+      const auto operation = wait_all ? std::all_of<iter_t, decltype(signal_predicate)>
+                                      : std::any_of<iter_t, decltype(signal_predicate)>;
+      wait_predicate = [&handles, &alertable_predicate, operation, signal_predicate] {
+        return alertable_predicate() ||
+               operation(handles.cbegin(), handles.cend(), signal_predicate);
+      };
+    }
+
+    std::unique_lock<std::mutex> lock(PosixConditionBase::mutex_);
+    bool wait_success = true;
+    if (timeout == std::chrono::milliseconds::max()) {
+      PosixConditionBase::cond_.wait(lock, wait_predicate);
+    } else {
+      wait_success = PosixConditionBase::cond_.wait_for(lock, timeout, wait_predicate);
+    }
+    if (!wait_success) {
+      return std::make_pair<WaitResult, size_t>(WaitResult::kTimeout, 0);
+    }
+
+    if (alertable_predicate()) {
+      return std::make_pair<WaitResult, size_t>(WaitResult::kUserCallback, 0);
+    }
+
+    auto first_signaled = std::numeric_limits<size_t>::max();
+    for (auto i = 0u; i < handles.size(); ++i) {
+      if (handles[i]->signaled()) {
+        if (first_signaled > i) {
+          first_signaled = i;
+        }
+        handles[i]->post_execution();
+        if (!wait_all)
+          break;
+      }
+    }
+    assert_true(std::numeric_limits<size_t>::max() != first_signaled);
+    return std::make_pair(WaitResult::kSuccess, first_signaled);
+  }
+
+  static bool WaitForAlertable(const std::function<bool()>& alertable_predicate,
+                               std::chrono::microseconds timeout) {
+    auto predicate = [&alertable_predicate] { return alertable_predicate(); };
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (predicate()) {
+      return true;
+    }
+    return cond_.wait_for(lock, timeout, predicate);
   }
 
   virtual void* native_handle() const { return cond_.native_handle(); }
@@ -656,21 +736,46 @@ class PosixCondition<Thread> : public PosixConditionBase {
   }
 
   void QueueUserCallback(std::function<void()> callback) {
+    if (!callback) {
+      return;
+    }
     WaitStarted();
-    std::unique_lock<std::mutex> lock(callback_mutex_);
-    user_callback_ = std::move(callback);
-    sigval value{};
-    value.sival_ptr = this;
-#if REX_PLATFORM_ANDROID
-    sigqueue(pthread_gettid_np(thread_), GetSystemSignal(SignalType::kThreadUserCallback), value);
-#else
-    pthread_sigqueue(thread_, GetSystemSignal(SignalType::kThreadUserCallback), value);
-#endif
+    {
+      std::unique_lock<std::mutex> lock(state_mutex_);
+      if (state_ == State::kFinished) {
+        return;
+      }
+    }
+    {
+      std::unique_lock<std::mutex> lock(callback_mutex_);
+      user_callbacks_.push_back(std::move(callback));
+      user_callback_count_.fetch_add(1, std::memory_order_release);
+    }
+    cond_.notify_all();
   }
 
-  void CallUserCallback() {
-    std::unique_lock<std::mutex> lock(callback_mutex_);
-    user_callback_();
+  bool HasPendingUserCallbacks() const {
+    return user_callback_count_.load(std::memory_order_acquire) != 0;
+  }
+
+  bool DispatchQueuedUserCallbacks() {
+    bool dispatched = false;
+    for (;;) {
+      std::function<void()> callback;
+      {
+        std::unique_lock<std::mutex> lock(callback_mutex_);
+        if (user_callbacks_.empty()) {
+          break;
+        }
+        callback = std::move(user_callbacks_.front());
+        user_callbacks_.pop_front();
+        assert_true(user_callback_count_.load(std::memory_order_relaxed) > 0);
+        user_callback_count_.fetch_sub(1, std::memory_order_release);
+      }
+      callback();
+      dispatched = true;
+    }
+    return dispatched;
   }
 
   bool Resume(uint32_t* out_previous_suspend_count = nullptr) {
@@ -775,7 +880,8 @@ class PosixCondition<Thread> : public PosixConditionBase {
   mutable std::mutex state_mutex_;
   mutable std::mutex callback_mutex_;
   mutable std::condition_variable state_signal_;
-  std::function<void()> user_callback_;
+  std::deque<std::function<void()>> user_callbacks_;
+  std::atomic<uint32_t> user_callback_count_{0};
 #if REX_PLATFORM_ANDROID
   // Name accessible via name() on Android before API 26 which added
   // pthread_getname_np.
@@ -827,16 +933,74 @@ PosixConditionHandle<Event>::PosixConditionHandle(bool manual_reset, bool initia
 template <>
 PosixConditionHandle<Thread>::PosixConditionHandle(pthread_t thread) : handle_(thread) {}
 
+namespace {
+class AlertableStateGuard {
+ public:
+  AlertableStateGuard() { alertable_state_ = true; }
+  ~AlertableStateGuard() { alertable_state_ = false; }
+};
+
+PosixCondition<Thread>* GetCurrentThreadCondition() {
+  auto* current_thread = Thread::GetCurrentThread();
+  if (!current_thread) {
+    return nullptr;
+  }
+  auto* current_posix_thread = dynamic_cast<PosixConditionHandle<Thread>*>(current_thread);
+  if (!current_posix_thread) {
+    return nullptr;
+  }
+  return &current_posix_thread->condition();
+}
+
+bool CurrentThreadHasPendingUserCallbacks() {
+  auto* current_thread = GetCurrentThreadCondition();
+  if (!current_thread) {
+    return false;
+  }
+  return current_thread->HasPendingUserCallbacks();
+}
+
+bool DispatchCurrentThreadUserCallbacks() {
+  auto* current_thread = GetCurrentThreadCondition();
+  if (!current_thread) {
+    return false;
+  }
+  if (!current_thread->HasPendingUserCallbacks()) {
+    return false;
+  }
+  return current_thread->DispatchQueuedUserCallbacks();
+}
+
+}  // namespace
+
+SleepResult AlertableSleep(std::chrono::microseconds duration) {
+  AlertableStateGuard alertable_guard;
+  if (DispatchCurrentThreadUserCallbacks()) {
+    return SleepResult::kAlerted;
+  }
+
+  if (PosixConditionBase::WaitForAlertable(CurrentThreadHasPendingUserCallbacks, duration)) {
+    DispatchCurrentThreadUserCallbacks();
+    return SleepResult::kAlerted;
+  }
+  return SleepResult::kSuccess;
+}
+
 WaitResult Wait(WaitHandle* wait_handle, bool is_alertable, std::chrono::milliseconds timeout) {
   auto posix_wait_handle = dynamic_cast<PosixWaitHandle*>(wait_handle);
   if (posix_wait_handle == nullptr) {
     return WaitResult::kFailed;
   }
-  if (is_alertable)
-    alertable_state_ = true;
-  auto result = posix_wait_handle->condition().Wait(timeout);
-  if (is_alertable)
-    alertable_state_ = false;
+  if (!is_alertable) {
+    return posix_wait_handle->condition().Wait(timeout);
+  }
+
+  AlertableStateGuard alertable_guard;
+  auto result =
+      posix_wait_handle->condition().WaitAlertable(CurrentThreadHasPendingUserCallbacks, timeout);
+  if (result == WaitResult::kUserCallback) {
+    DispatchCurrentThreadUserCallbacks();
+  }
   return result;
 }
 
@@ -848,13 +1012,18 @@ WaitResult SignalAndWait(WaitHandle* wait_handle_to_signal, WaitHandle* wait_han
   if (posix_wait_handle_to_signal == nullptr || posix_wait_handle_to_wait_on == nullptr) {
     return WaitResult::kFailed;
   }
-  if (is_alertable)
-    alertable_state_ = true;
   if (posix_wait_handle_to_signal->condition().Signal()) {
-    result = posix_wait_handle_to_wait_on->condition().Wait(timeout);
+    if (!is_alertable) {
+      result = posix_wait_handle_to_wait_on->condition().Wait(timeout);
+    } else {
+      AlertableStateGuard alertable_guard;
+      result = posix_wait_handle_to_wait_on->condition().WaitAlertable(
+          CurrentThreadHasPendingUserCallbacks, timeout);
+      if (result == WaitResult::kUserCallback) {
+        DispatchCurrentThreadUserCallbacks();
+      }
+    }
   }
-  if (is_alertable)
-    alertable_state_ = false;
   return result;
 }
 
@@ -870,11 +1039,16 @@ std::pair<WaitResult, size_t> WaitMultiple(WaitHandle* wait_handles[], size_t wa
     }
     conditions.push_back(&handle->condition());
   }
-  if (is_alertable)
-    alertable_state_ = true;
-  auto result = PosixConditionBase::WaitMultiple(std::move(conditions), wait_all, timeout);
-  if (is_alertable)
-    alertable_state_ = false;
+  if (!is_alertable) {
+    return PosixConditionBase::WaitMultiple(conditions, wait_all, timeout);
+  }
+
+  AlertableStateGuard alertable_guard;
+  auto result = PosixConditionBase::WaitMultipleAlertable(conditions, wait_all, timeout,
+                                                          CurrentThreadHasPendingUserCallbacks);
+  if (result.first == WaitResult::kUserCallback) {
+    DispatchCurrentThreadUserCallbacks();
+  }
   return result;
 }
 
@@ -1081,7 +1255,6 @@ void* PosixCondition<Thread>::ThreadStartRoutine(void* parameter) {
 std::unique_ptr<Thread> Thread::Create(CreationParameters params,
                                        std::function<void()> start_routine) {
   install_signal_handler(SignalType::kThreadSuspend);
-  install_signal_handler(SignalType::kThreadUserCallback);
 #if REX_PLATFORM_ANDROID
   install_signal_handler(SignalType::kThreadTerminate);
 #endif
@@ -1137,11 +1310,7 @@ static void signal_handler(int signal, siginfo_t* info, void* /*context*/) {
       current_thread_->WaitSuspended();
     } break;
     case SignalType::kThreadUserCallback: {
-      assert_not_null(info->si_value.sival_ptr);
-      auto p_thread = static_cast<PosixCondition<Thread>*>(info->si_value.sival_ptr);
-      if (alertable_state_) {
-        p_thread->CallUserCallback();
-      }
+      (void)info;
     } break;
 #if REX_PLATFORM_ANDROID
     case SignalType::kThreadTerminate: {

--- a/src/system/xmemory.cpp
+++ b/src/system/xmemory.cpp
@@ -131,10 +131,17 @@ bool Memory::Initialize() {
 
   // Create main page file-backed mapping. This is all reserved but
   // uncommitted (so it shouldn't expand page file).
-  mapping_ =
-      rex::memory::CreateFileMappingHandle(file_name_,
-                                           // entire 4gb space + 512mb physical:
-                                           0x11FFFFFFF, rex::memory::PageAccess::kReadWrite, false);
+  //
+  // Base space is 4 GB virtual + 512 MB physical = 0x120000000 bytes.
+  // On systems with 4 KB allocation granularity, the 0xE0000000 view keeps a
+  // +0x1000 file offset (see map_info / host_address_offset handling), so the
+  // mapping object must include an extra page.
+  uint64_t mapping_length = 0x120000000ull;
+  if (system_allocation_granularity_ <= 0x1000) {
+    mapping_length += 0x1000ull;
+  }
+  mapping_ = rex::memory::CreateFileMappingHandle(file_name_, mapping_length,
+                                                  rex::memory::PageAccess::kReadWrite, false);
   if (mapping_ == rex::memory::kFileMappingHandleInvalid) {
     REXSYS_ERROR("Unable to reserve the 4gb guest address space.");
     assert_always();
@@ -284,6 +291,14 @@ int Memory::MapViews(uint8_t* mapping_base) {
         map_info[n].virtual_address_end - map_info[n].virtual_address_start + 1,
         rex::memory::PageAccess::kReadWrite, map_info[n].target_address & granularity_mask));
     if (!views_.all_views[n]) {
+      REXSYS_WARN(
+          "MapViews failed at segment {}: base={} length={:08X} file_offset={:016X} "
+          "granularity={:08X}",
+          n, fmt::ptr(mapping_base + map_info[n].virtual_address_start),
+          static_cast<uint32_t>(map_info[n].virtual_address_end -
+                                map_info[n].virtual_address_start + 1),
+          static_cast<uint64_t>(map_info[n].target_address & granularity_mask),
+          system_allocation_granularity_);
       // Failed, so bail and try again.
       UnmapViews();
       return 1;


### PR DESCRIPTION
Fable 2 uses async threading. This implementation fixes it and allows it to run.

src/core/threading_posix.cpp

Reworked POSIX APC/callback flow to queue callbacks (std::deque + atomic count) instead of single-slot callback overwrite.
Removed callback execution from signal context (kThreadUserCallback handler is now no-op; no user-callback signal handler install on create).
Added alertable wait helpers: WaitAlertable, WaitMultipleAlertable, WaitForAlertable.
Wait, SignalAndWait, WaitMultiple, and AlertableSleep now support kUserCallback / kAlerted behavior on POSIX and dispatch callbacks outside locks.
Added AlertableStateGuard + current-thread callback dispatch helpers.

src/core/mapped_memory_posix.cpp

Implemented POSIX MappedMemory::Remap.
Added offset alignment handling for mapping/open/remap paths.
Implemented POSIX ChunkedMappedMemoryWriter (chunk files + mmap + flush/flushnew).
Added low-address best-effort via MAP_32BIT on Linux x86_64.
Optimized FlushNew to flush only delta range (last_flush_offset_..offset_).

src/core/memory_posix.cpp

Cached page_size() and allocation_granularity().
Added page-alignment helper and applied it to Protect and DeallocFixed(kDecommit).
Reworked /proc/self/maps parsing to FILE* + fgets + sscanf with thread-local scratch vector.
Improved QueryProtect semantics to return contiguous same-protection region length.
POSIX shared mapping creation now rounds size to page size.
MapFileView now validates mapping bounds using fstat64 and overflow-safe end checks.

src/system/xmemory.cpp

Adjusted mapping object length in Memory::Initialize:
base 0x120000000, plus 0x1000 extra on 4K granularity systems.