### PR TITLE
feat: add content package header functionality

### DIFF
--- a/include/rex/system/xam/content_manager.h
+++ b/include/rex/system/xam/content_manager.h
@@ -147,6 +147,9 @@ class ContentManager {
                                                  const XCONTENT_AGGREGATE_DATA& data);
 
   bool ContentExists(const XCONTENT_AGGREGATE_DATA& data);
+  X_RESULT WriteContentHeaderFile(XCONTENT_AGGREGATE_DATA data);
+  X_RESULT ReadContentHeaderFile(const std::string_view file_name, const uint32_t title_id,
+                                 XContentType content_type, XCONTENT_AGGREGATE_DATA& data);
   X_RESULT CreateContent(const std::string_view root_name, const XCONTENT_AGGREGATE_DATA& data);
   X_RESULT OpenContent(const std::string_view root_name, const XCONTENT_AGGREGATE_DATA& data);
   X_RESULT CloseContent(const std::string_view root_name);
@@ -163,6 +166,9 @@ class ContentManager {
  private:
   std::filesystem::path ResolvePackageRoot(XContentType content_type, uint32_t title_id = -1);
   std::filesystem::path ResolvePackagePath(const XCONTENT_AGGREGATE_DATA& data);
+  std::filesystem::path ResolvePackageHeaderPath(const std::string_view file_name,
+                                                 uint32_t title_id,
+                                                 const XContentType content_type);
 
   KernelState* kernel_state_;
   std::filesystem::path root_path_;

--- a/src/kernel/xam/xam_content.cpp
+++ b/src/kernel/xam/xam_content.cpp
@@ -88,7 +88,8 @@ ppc_u32_result_t XamContentCreateEnumerator_entry(ppc_u32_t user_index, ppc_u32_
   if (!device_info || device_info->device_id == DummyDeviceId::HDD) {
     // Get all content data.
     auto content_datas = kernel_state()->content_manager()->ListContent(
-        static_cast<uint32_t>(DummyDeviceId::HDD), XContentType(uint32_t(content_type)));
+        static_cast<uint32_t>(DummyDeviceId::HDD), XContentType(uint32_t(content_type)),
+        kernel_state()->title_id());
     for (const auto& content_data : content_datas) {
       auto item = e->AppendItem();
       *item = content_data;
@@ -180,6 +181,9 @@ ppc_u32_result_t xeXamContentCreate(ppc_u32_t user_index, ppc_pchar_t root_name,
 
     if (disposition == kDispositionState::Create) {
       result = content_manager->CreateContent(root_name, content_data);
+      if (XSUCCEEDED(result)) {
+        content_manager->WriteContentHeaderFile(content_data);
+      }
     } else if (disposition == kDispositionState::Open) {
       result = content_manager->OpenContent(root_name, content_data);
     }

--- a/src/system/xam/content_manager.cpp
+++ b/src/system/xam/content_manager.cpp
@@ -27,6 +27,8 @@ namespace xam {
 
 static const char* kThumbnailFileName = "__thumbnail.png";
 
+static const char* kGameContentHeaderDirName = "Headers";
+
 static const char* kGameUserContentDirName = "profile";
 
 static int content_device_id_ = 0;
@@ -95,13 +97,19 @@ std::vector<XCONTENT_AGGREGATE_DATA> ContentManager::ListContent(uint32_t device
       // Directories only.
       continue;
     }
+
     XCONTENT_AGGREGATE_DATA content_data;
-    content_data.device_id = device_id;
-    content_data.content_type = content_type;
-    content_data.set_display_name(rex::path_to_utf16(file_info.name));
-    content_data.set_file_name(rex::path_to_utf8(file_info.name));
-    content_data.title_id = title_id;
-    result.emplace_back(std::move(content_data));
+    if (XSUCCEEDED(ReadContentHeaderFile(rex::path_to_utf8(file_info.name), title_id, content_type,
+                                         content_data))) {
+      result.emplace_back(std::move(content_data));
+    } else {
+      content_data.device_id = device_id;
+      content_data.content_type = content_type;
+      content_data.set_display_name(rex::path_to_utf16(file_info.name));
+      content_data.set_file_name(rex::path_to_utf8(file_info.name));
+      content_data.title_id = title_id;
+      result.emplace_back(std::move(content_data));
+    }
   }
 
   return result;
@@ -120,9 +128,80 @@ std::unique_ptr<ContentPackage> ContentManager::ResolvePackage(
   return package;
 }
 
+std::filesystem::path ContentManager::ResolvePackageHeaderPath(const std::string_view file_name,
+                                                               uint32_t title_id,
+                                                               const XContentType content_type) {
+  if (title_id == kCurrentlyRunningTitleId) {
+    title_id = kernel_state_->title_id();
+  }
+
+  auto title_id_str = std::format("{:08X}", title_id);
+  auto content_type_str = std::format("{:08X}", uint32_t(content_type));
+  std::string final_name = std::filesystem::path(file_name).filename().u8string() + ".header";
+
+  // Header root path:
+  // content_root/title_id/Headers/content_type/
+  return root_path_ / title_id_str / kGameContentHeaderDirName / content_type_str / final_name;
+}
+
 bool ContentManager::ContentExists(const XCONTENT_AGGREGATE_DATA& data) {
   auto path = ResolvePackagePath(data);
   return std::filesystem::exists(path);
+}
+
+X_RESULT ContentManager::WriteContentHeaderFile(XCONTENT_AGGREGATE_DATA data) {
+  if (data.title_id == -1) {
+    data.title_id = kernel_state_->title_id();
+  }
+
+  auto header_path = ResolvePackageHeaderPath(data.file_name(), data.title_id, data.content_type);
+  auto parent_path = header_path.parent_path();
+
+  if (!std::filesystem::exists(parent_path)) {
+    if (!std::filesystem::create_directories(parent_path)) {
+      return X_STATUS_ACCESS_DENIED;
+    }
+  }
+
+  rex::filesystem::CreateEmptyFile(header_path);
+
+  if (std::filesystem::exists(header_path)) {
+    auto file = rex::filesystem::OpenFile(header_path, "wb");
+    fwrite(&data, 1, sizeof(XCONTENT_AGGREGATE_DATA), file);
+    fclose(file);
+    return X_STATUS_SUCCESS;
+  }
+  return X_STATUS_NO_SUCH_FILE;
+}
+
+X_RESULT ContentManager::ReadContentHeaderFile(const std::string_view file_name,
+                                               const uint32_t title_id, XContentType content_type,
+                                               XCONTENT_AGGREGATE_DATA& data) {
+  auto header_file_path = ResolvePackageHeaderPath(file_name, title_id, content_type);
+  constexpr uint32_t header_size = sizeof(XCONTENT_AGGREGATE_DATA);
+
+  if (std::filesystem::exists(header_file_path)) {
+    auto file = rex::filesystem::OpenFile(header_file_path, "rb");
+
+    std::array<uint8_t, header_size> buffer;
+
+    auto file_size = std::filesystem::file_size(header_file_path);
+    if (file_size < header_size) {
+      fclose(file);
+      return X_STATUS_END_OF_FILE;
+    }
+
+    size_t result = fread(buffer.data(), 1, header_size, file);
+    if (result != header_size) {
+      fclose(file);
+      return X_STATUS_END_OF_FILE;
+    }
+
+    fclose(file);
+    std::memcpy(&data, buffer.data(), buffer.size());
+    return X_STATUS_SUCCESS;
+  }
+  return X_STATUS_NO_SUCH_FILE;
 }
 
 X_RESULT ContentManager::CreateContent(const std::string_view root_name,


### PR DESCRIPTION
Games may store additional data in headers for content such as saves. If a game expects this data but does not receive it as previously, then it may crash. Fixes #193.