### PR TITLE
Adjust input buffer read offset in xma_context

### DIFF
--- a/src/audio/xma_context.cpp
+++ b/src/audio/xma_context.cpp
@@ -319,7 +319,7 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
 
   // No available data.
   if (!data->input_buffer_0_valid && !data->input_buffer_1_valid) {
-    data->output_buffer_valid = 0;
+    data->input_buffer_read_offset = 0x20;
     return;
   }
 
@@ -378,6 +378,7 @@ void XmaContext::Decode(XMA_CONTEXT_DATA* data) {
   // Decode until we can't write any more data.
   while (output_remaining_bytes > 0) {
     if (!data->input_buffer_0_valid && !data->input_buffer_1_valid) {
+      data->input_buffer_read_offset += 0x20;
       // Out of data.
       break;
     }


### PR DESCRIPTION
Ports this [commit](https://github.com/xenia-canary/xenia-canary/commit/1e469f6e59a32c1670774ba8b9d4375997450bc2) from xenia canary to rexglue.

This should fix some audio looping issues, especially the looping sounds in the crackdown 2 main menu screen.