### PR TITLE
Update xam_ui.cpp (Fixed Text Input Display/Crash)

### DIFF
--- a/src/kernel/xam/xam_ui.cpp
+++ b/src/kernel/xam/xam_ui.cpp
@@ -463,12 +463,16 @@ ppc_u32_result_t XamShowKeyboardUI_entry(ppc_u32_t user_index, ppc_u32_t flags,
     };
     const Runtime* emulator = kernel_state()->emulator();
     ui::ImGuiDrawer* imgui_drawer = emulator->imgui_drawer();
+
+    // Read and convert title/description/default_text from guest memory as utf16 to utf8 strings
+    std::string title_str = title ? rex::string::to_utf8(rex::memory::load_and_swap<std::u16string>(kernel_state()->memory()->TranslateVirtual(title.guest_address()))) : "";
+    std::string desc_str = description ? rex::string::to_utf8(rex::memory::load_and_swap<std::u16string>(kernel_state()->memory()->TranslateVirtual(description.guest_address()))) : "";
+    std::string def_text_str = default_text ? rex::string::to_utf8(rex::memory::load_and_swap<std::u16string>(kernel_state()->memory()->TranslateVirtual(default_text.guest_address()))) : "";
+
     if (imgui_drawer) {
+      uint32_t buffer_length_safe = buffer_length + 1;  // +1 for null terminator, just in case
       result = xeXamDispatchDialogEx<KeyboardInputDialog>(
-          new KeyboardInputDialog(imgui_drawer, title ? rex::string::to_utf8(title.value()) : "",
-                                  description ? rex::string::to_utf8(description.value()) : "",
-                                  default_text ? rex::string::to_utf8(default_text.value()) : "",
-                                  buffer_length),
+          new KeyboardInputDialog(imgui_drawer, title_str, desc_str, def_text_str, buffer_length_safe),
           close, overlapped.guest_address());
     } else {
       // Fallback to headless


### PR DESCRIPTION
Changed the text input so it can read utf16 strings and also includes a buffer size + 1 so that we can include the null terminator for stability

I've tested 3 different games across engines and all the the input boxes look fine with this change, before it was garbage

Before:
<img width="267" height="147" alt="image" src="https://github.com/user-attachments/assets/419f8c62-593e-4400-acab-b1f63d571dc8" />
After:
<img width="175" height="97" alt="image" src="https://github.com/user-attachments/assets/bec7d3b2-c9de-48b7-8dce-9d5659f753ca" />

This also fixes a crash in Banjo Kazooie N&B caused by returning garbage data without a null terminator

Fixes #199
