### PR TITLE
Added `OnLoadXexImage`

### DIFF
--- a/include/rex/rex_app.h
+++ b/include/rex/rex_app.h
@@ -85,6 +85,9 @@ class ReXApp : public ui::WindowedApp, public ui::WindowListener, public ui::Win
   /// Called before Runtime::Setup(). Override to modify backend config.
   virtual void OnPreSetup(RuntimeConfig& config) {}
 
+  /// Called before Runtime::LoadXexImage(). Override to modify xex image.
+  virtual void OnLoadXexImage(std::string& xex_image) {}
+
   /// Called after runtime is fully initialized, before window creation.
   virtual void OnPostSetup() {}
 

--- a/src/rexglue/commands/template_utils.h
+++ b/src/rexglue/commands/template_utils.h
@@ -188,6 +188,7 @@ inline std::string generate_app_header(const AppNameParts& names) {
   content += "\n";
   content += "  // Override virtual hooks for customization:\n";
   content += "  // void OnPreSetup(rex::RuntimeConfig& config) override {}\n";
+  content += "  // void OnLoadXexImage(std::string& xex_image) override {}\n";
   content += "  // void OnPostSetup() override {}\n";
   content += "  // void OnCreateDialogs(rex::ui::ImGuiDrawer* drawer) override {}\n";
   content += "  // void OnShutdown() override {}\n";

--- a/src/ui/rex_app.cpp
+++ b/src/ui/rex_app.cpp
@@ -138,8 +138,13 @@ bool ReXApp::OnInitialize() {
     return false;
   }
 
+  std::string xex_image = "game:\\default.xex";
+
+  // Allow subclass to override xex image
+  OnLoadXexImage(xex_image);
+
   // Load XEX image
-  status = runtime_->LoadXexImage("game:\\default.xex");
+  status = runtime_->LoadXexImage(xex_image);
   if (XFAILED(status)) {
     REXLOG_ERROR("Failed to load XEX: {:08X}", status);
     return false;


### PR DESCRIPTION
Some in development builds of games don't contain `default.xex`, this let's the user specify what xex to use.