### PR TITLE
Added Command CVAR with std::function<void()>

### DIFF
--- a/include/rex/cvar.h
+++ b/include/rex/cvar.h
@@ -12,7 +12,7 @@
  * REXCVAR_DEFINE_STRING(my_string, "default", "Category", "A string setting");
  * @endcode
  *
- * Available types: BOOL, INT32, INT64, UINT32, UINT64, DOUBLE, STRING
+ * Available types: BOOL, INT32, INT64, UINT32, UINT64, DOUBLE, STRING, COMMAND
  *
  * @section cvar_declaring Declaring CVars (for use in other files)
  *
@@ -114,7 +114,7 @@ void SaveConfig(const std::filesystem::path& config_path);
 // Flag Registry
 //=============================================================================
 
-enum class FlagType { Boolean, Int32, Int64, Uint32, Uint64, Double, String };
+enum class FlagType { Boolean, Int32, Int64, Uint32, Uint64, Double, String, Command };
 
 // Lifecycle: when can this flag be modified?
 enum class Lifecycle {
@@ -141,6 +141,7 @@ struct FlagEntry {
   std::string description;
   std::function<bool(std::string_view)> setter;
   std::function<std::string()> getter;
+  std::function<void()> command_callback;
   Lifecycle lifecycle = Lifecycle::kHotReload;
   Constraints constraints;
   std::string default_value;
@@ -264,6 +265,7 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                     return true;                                        \
                                   },                                                    \
                                   []() { return FLAGS_##name ? "true" : "false"; },     \
+                                  []() { return; },                                     \
                                   ::rex::cvar::Lifecycle::kHotReload,                   \
                                   {},                                                   \
                                   (default_val) ? "true" : "false",                     \
@@ -286,6 +288,7 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                     return true;                                             \
                                   },                                                         \
                                   []() { return std::to_string(FLAGS_##name); },             \
+                                  []() { return; },                                          \
                                   ::rex::cvar::Lifecycle::kHotReload,                        \
                                   {},                                                        \
                                   std::to_string(default_val),                               \
@@ -308,6 +311,7 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                     return true;                                             \
                                   },                                                         \
                                   []() { return std::to_string(FLAGS_##name); },             \
+                                  []() { return; },                                          \ 
                                   ::rex::cvar::Lifecycle::kHotReload,                        \
                                   {},                                                        \
                                   std::to_string(default_val),                               \
@@ -330,6 +334,7 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                     return true;                                             \
                                   },                                                         \
                                   []() { return std::to_string(FLAGS_##name); },             \
+                                  []() { return; },                                          \
                                   ::rex::cvar::Lifecycle::kHotReload,                        \
                                   {},                                                        \
                                   std::to_string(default_val),                               \
@@ -352,6 +357,7 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                     return true;                                             \
                                   },                                                         \
                                   []() { return std::to_string(FLAGS_##name); },             \
+                                  []() { return; },                                          \
                                   ::rex::cvar::Lifecycle::kHotReload,                        \
                                   {},                                                        \
                                   std::to_string(default_val),                               \
@@ -372,6 +378,7 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                     return true;                                 \
                                   },                                             \
                                   []() { return std::to_string(FLAGS_##name); }, \
+                                  []() { return; },                              \
                                   ::rex::cvar::Lifecycle::kHotReload,            \
                                   {},                                            \
                                   std::to_string(default_val),                   \
@@ -388,10 +395,26 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                                                return true;                      \
                                                              },                                  \
                                                              []() { return FLAGS_##name; },      \
+                                                             []() { return; },                   \
                                                              ::rex::cvar::Lifecycle::kHotReload, \
                                                              {},                                 \
                                                              default_val,                        \
                                                              false})
+
+#define REXCVAR_DEFINE_COMMAND(name, callback, category, desc)                                          \
+  std::function<void()> FLAGS_##name = (callback);                                                      \
+  static auto _cvar_reg_##name = ::rex::cvar::FlagRegistrar({#name,                                     \
+                                                             ::rex::cvar::FlagType::Command,            \
+                                                             category,                                  \
+                                                             desc,                                      \
+                                                             [](std::string_view) { return false; },    \
+                                                             []() { return "<command>"; },              \
+                                                             callback,                                  \
+                                                             ::rex::cvar::Lifecycle::kHotReload,        \
+                                                             {},                                        \
+                                                             "<command>",                               \
+                                                             false})
+
 
 namespace rex::cvar {
 namespace testing {

--- a/src/ui/overlay/settings_overlay.cpp
+++ b/src/ui/overlay/settings_overlay.cpp
@@ -484,6 +484,10 @@ void SettingsDialog::OnDraw(ImGuiIO& /*io*/) {
             v = std::min(v, *entry.constraints.max);
           rex::cvar::SetFlagByName(entry.name, std::to_string(v));
         }
+      } else if (entry.type == rex::cvar::FlagType::Command) {
+        if (ImGui::Button(std::string(entry.name + "##v").c_str())) {
+          entry.command_callback();
+        }
       } else {
         char buf[256];
         std::strncpy(buf, current_val.c_str(), sizeof(buf) - 1);


### PR DESCRIPTION
Adds a CVAR that stores a std::function<void()>, The F4 menu then calls the function using a ImGui Button. This is useful for actions like "Unlock All Items" rather then having to hook a tick function and check a BOOL CVAR we can use this command instead.

This is a Rewrite/Retargeting of #260 rather then using a void function pointer I switched over to std::function<void()> and reworded it to "Command" rather then "Trigger"

<img width="1093" height="135" alt="image" src="https://github.com/user-attachments/assets/72b56595-3ccf-4dd3-a355-3d88d93b8fc9" />

<img width="826" height="152" alt="image" src="https://github.com/user-attachments/assets/648a2154-09b4-4160-9785-fa9d73f70bd3" />

Implementation of #259 