### PR TITLE
Implement multiple missing Oppcodes

### DIFF
--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -482,6 +482,7 @@ bool build_vminsh(BuilderContext& ctx);
 bool build_vminsb(BuilderContext& ctx);
 bool build_vminsw(BuilderContext& ctx);
 bool build_vminuh(BuilderContext& ctx);
+bool build_vminuw(BuilderContext& ctx);
 bool build_vmaxub(BuilderContext& ctx);
 bool build_vminub(BuilderContext& ctx);
 

--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -335,6 +335,7 @@ bool build_stwu(BuilderContext& ctx);
 bool build_stwux(BuilderContext& ctx);
 bool build_stwx(BuilderContext& ctx);
 bool build_stwbrx(BuilderContext& ctx);
+bool build_stmw(BuilderContext& ctx);
 
 // Atomic store conditional
 bool build_stwcx(BuilderContext& ctx);

--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -366,6 +366,7 @@ bool build_lvsl(BuilderContext& ctx);
 bool build_lvsr(BuilderContext& ctx);
 
 // Vector stores
+bool build_stvebx(BuilderContext& ctx);
 bool build_stvehx(BuilderContext& ctx);
 bool build_stvewx(BuilderContext& ctx);
 bool build_stvlx(BuilderContext& ctx);

--- a/src/codegen/builders.h
+++ b/src/codegen/builders.h
@@ -218,6 +218,7 @@ bool build_fmr(BuilderContext& ctx);
 bool build_fcfid(BuilderContext& ctx);
 bool build_fctid(BuilderContext& ctx);
 bool build_fctidz(BuilderContext& ctx);
+bool build_fctiw(BuilderContext& ctx);
 bool build_fctiwz(BuilderContext& ctx);
 bool build_frsp(BuilderContext& ctx);
 

--- a/src/codegen/builders/floating_point.cpp
+++ b/src/codegen/builders/floating_point.cpp
@@ -76,6 +76,16 @@ bool build_fctidz(BuilderContext& ctx) {
   return true;
 }
 
+bool build_fctiw(BuilderContext& ctx) {
+  ctx.emit_set_flush_mode(false);
+  ctx.println(
+      "\t{0}.s64 = std::isnan({1}.f64) ? int64_t(0x80000000U) : "
+      "({1}.f64 > double(INT_MAX)) ? INT_MAX : "
+      "simde_mm_cvtsd_si32(simde_mm_load_sd(&{1}.f64));",
+      ctx.f(ctx.insn.operands[0]), ctx.f(ctx.insn.operands[1]));
+  return true;
+}
+
 bool build_fctiwz(BuilderContext& ctx) {
   ctx.emit_set_flush_mode(false);
   ctx.println(

--- a/src/codegen/builders/memory.cpp
+++ b/src/codegen/builders/memory.cpp
@@ -380,6 +380,21 @@ bool build_stwx(BuilderContext& ctx) {
   return true;
 }
 
+bool build_stmw(BuilderContext& ctx) {
+  // EA = (rA == 0 ? 0 : r[rA]) + EXTS(d); store r[rS]..r[31] at EA, EA+4, ...
+  uint32_t rS = ctx.insn.operands[0];
+  int32_t offset = static_cast<int32_t>(ctx.insn.operands[1]);
+  uint32_t rA = ctx.insn.operands[2];
+  if (rA != 0)
+    ctx.println("\t{} = {}.u32 + {};", ctx.ea(), ctx.r(rA), offset);
+  else
+    ctx.println("\t{} = {};", ctx.ea(), offset);
+  for (uint32_t i = rS; i <= 31; ++i) {
+    ctx.println("\tPPC_STORE_U32({} + {}, {}.u32);", ctx.ea(), (i - rS) * 4, ctx.r(i));
+  }
+  return true;
+}
+
 bool build_stwbrx(BuilderContext& ctx) {
   ctx.print("{}", ctx.mmio_check_x_form() ? "\tPPC_MM_STORE_U32(" : "\tPPC_STORE_U32(");
   if (ctx.insn.operands[1] != 0)

--- a/src/codegen/builders/memory.cpp
+++ b/src/codegen/builders/memory.cpp
@@ -596,6 +596,15 @@ bool build_lvsr(BuilderContext& ctx) {
 // Vector Stores
 //=============================================================================
 
+bool build_stvebx(BuilderContext& ctx) {
+  // TODO(tomc): vectorize
+  // NOTE: accounting for the full vector reversal here
+  emitVectorEA(ctx);
+  ctx.println("\tPPC_STORE_U8({}, {}.u8[15 - ({} & 0xF)]);", ctx.ea(),
+              ctx.v(ctx.insn.operands[0]), ctx.ea());
+  return true;
+}
+
 bool build_stvehx(BuilderContext& ctx) {
   // TODO(tomc): vectorize
   // NOTE: accounting for the full vector reversal here

--- a/src/codegen/builders/vector.cpp
+++ b/src/codegen/builders/vector.cpp
@@ -384,6 +384,11 @@ bool build_vminuh(BuilderContext& ctx) {
   return true;
 }
 
+bool build_vminuw(BuilderContext& ctx) {
+  ctx.emit_vec_int_binary("min_epu32", "u32");
+  return true;
+}
+
 bool build_vsubsbs(BuilderContext& ctx) {
   ctx.emit_vec_int_binary("subs_epi8", "s8");
   return true;

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -282,6 +282,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable() {
       //=====================================================================
       {PPC_INST_LVX, build_lvx},
       {PPC_INST_LVX128, build_lvx},
+      {PPC_INST_LVXL, build_lvx},
       {PPC_INST_LVXL128, build_lvx},
       {PPC_INST_LVLX, build_lvlx},
       {PPC_INST_LVLX128, build_lvlx},

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -476,6 +476,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable() {
       {PPC_INST_VMINUH, build_vminuh},
       {PPC_INST_VMAXUB, build_vmaxub},
       {PPC_INST_VMINUB, build_vminub},
+      {PPC_INST_VMINUW, build_vminuw},
 
       //=====================================================================
       // Vector - Average

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -308,6 +308,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable() {
       {PPC_INST_STVRX128, build_stvrx},
       {PPC_INST_STVX, build_stvx},
       {PPC_INST_STVX128, build_stvx},
+      {PPC_INST_STVXL, build_stvx},
 
       //=====================================================================
       // System

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -298,6 +298,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable() {
       //=====================================================================
       // Memory - Vector Stores
       //=====================================================================
+      {PPC_INST_STVEBX, build_stvebx},
       {PPC_INST_STVEHX, build_stvehx},
       {PPC_INST_STVEWX, build_stvewx},
       {PPC_INST_STVEWX128, build_stvewx},

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -171,6 +171,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable() {
       {PPC_INST_FCFID, build_fcfid},
       {PPC_INST_FCTID, build_fctid},
       {PPC_INST_FCTIDZ, build_fctidz},
+      {PPC_INST_FCTIW, build_fctiw},
       {PPC_INST_FCTIWZ, build_fctiwz},
       {PPC_INST_FRSP, build_frsp},
       {PPC_INST_FCMPU, build_fcmpu},

--- a/src/codegen/instruction_dispatch.cpp
+++ b/src/codegen/instruction_dispatch.cpp
@@ -260,6 +260,7 @@ static const std::unordered_map<int, Builder>& GetDispatchTable() {
       {PPC_INST_STWUX, build_stwux},
       {PPC_INST_STWX, build_stwx},
       {PPC_INST_STWBRX, build_stwbrx},
+      {PPC_INST_STMW, build_stmw},
       {PPC_INST_STWCX, build_stwcx},
       {PPC_INST_STDCX, build_stdcx},
       {PPC_INST_STD, build_std},


### PR DESCRIPTION
Addresses missing oppcodes for #239 #174 #166 #220 #221 #222. One floating point, one vector, and a couple of memory oppcodes added and compiled. 