### PR TITLE
Add UTF-16 platform independent implementations for rexcrt

### DIFF
--- a/src/kernel/crt/string.cpp
+++ b/src/kernel/crt/string.cpp
@@ -107,34 +107,34 @@ static int native_lstrcmpiA(const char* s1, const char* s2) {
 // C UTF-16 Widestring functions (int16_t*)
 // ---------------------------------------------------------------------------
 
-static int native_wcslen(const int16_t* str) {
+static uint32_t native_wcslen(const int16_t* str) {
   const int16_t* last = str;
-  while ( *last++ )
-      ;
+  while (*last++)
+    ;
   return last - str - 1;
 }
 
-static int native_wcscmp(const int16_t* lhs, const int16_t* rhs) {
-  while(*lhs && (*lhs == *rhs)) {
+static uint32_t native_wcscmp(const int16_t* lhs, const int16_t* rhs) {
+  while (*lhs && (*lhs == *rhs)) {
     lhs++;
     rhs++;
   }
-  return (int)(*lhs)-(int)(*rhs);
+  return (int)(*lhs) - (int)(*rhs);
 }
 
-static int native_wcsncmp(const int16_t* lhs, const int16_t* rhs, int count) {
+static uint32_t native_wcsncmp(const int16_t* lhs, const int16_t* rhs, int count) {
   for (; count > 0; count--, lhs++, rhs++) {
     if (*lhs != *rhs)
-        return (int)(*lhs) - (int)(*rhs);
+      return (int)(*lhs) - (int)(*rhs);
 
     if (*lhs == L'\0')
-        return 0;
+      return 0;
   }
 
   return 0;
 }
 
-static int native_wcscoll(const int16_t* lhs, const int16_t* rhs) {
+static uint32_t native_wcscoll(const int16_t* lhs, const int16_t* rhs) {
   if (lhs && rhs)
     return native_wcscmp(lhs, rhs);
   return 22;  // EINVAL
@@ -147,13 +147,12 @@ static int16_t* native_wcschr(const int16_t* str, int16_t ch) {
   return (*str == ch) ? (int16_t*)str : 0;
 }
 
-static int16_t* native_wcsrchr(const int16_t* str, int16_t ch)
-{
+static int16_t* native_wcsrchr(const int16_t* str, int16_t ch) {
   const int16_t* res = 0;
 
   for (; *str; str++)
     if (*str == ch)
-        res = str;
+      res = str;
 
   return (int16_t*)(ch ? res : str);
 }
@@ -162,7 +161,7 @@ static int16_t* native_wcscpy(const int16_t* src, int16_t* dst) {
   int16_t* d = dst;
 
   while ((*d++ = *src++))
-      ;
+    ;
 
   return dst;
 }
@@ -176,7 +175,7 @@ static int16_t* native_wcsncpy(int16_t* dest, const int16_t* src, int count) {
   return dest;
 }
 
-static int native_wcsncpy_s(int16_t* dst, size_t dstsz, const int16_t* src, size_t count) {
+static uint32_t native_wcsncpy_s(int16_t* dst, size_t dstsz, const int16_t* src, size_t count) {
   if (!dst || !src || dstsz == 0)
     return 22;  // EINVAL
 
@@ -196,7 +195,7 @@ static int native_wcsncpy_s(int16_t* dst, size_t dstsz, const int16_t* src, size
   return 0;
 }
 
-int16_t* native_wcsstr(const int16_t* dest, const int16_t* src) {
+static int16_t* native_wcsstr(const int16_t* dest, const int16_t* src) {
   if (!*src)
     return (int16_t*)dest;
 

--- a/src/kernel/crt/string.cpp
+++ b/src/kernel/crt/string.cpp
@@ -103,6 +103,119 @@ static int native_lstrcmpiA(const char* s1, const char* s2) {
 #endif
 }
 
+// ---------------------------------------------------------------------------
+// C UTF-16 Widestring functions (int16_t*)
+// ---------------------------------------------------------------------------
+
+static int native_wcslen(const int16_t* str) {
+  const int16_t* last = str;
+  while ( *last++ )
+      ;
+  return last - str - 1;
+}
+
+static int native_wcscmp(const int16_t* lhs, const int16_t* rhs) {
+  while(*lhs && (*lhs == *rhs)) {
+    lhs++;
+    rhs++;
+  }
+  return (int)(*lhs)-(int)(*rhs);
+}
+
+static int native_wcsncmp(const int16_t* lhs, const int16_t* rhs, int count) {
+  for (; count > 0; count--, lhs++, rhs++) {
+    if (*lhs != *rhs)
+        return (int)(*lhs) - (int)(*rhs);
+
+    if (*lhs == L'\0')
+        return 0;
+  }
+
+  return 0;
+}
+
+static int native_wcscoll(const int16_t* lhs, const int16_t* rhs) {
+  if (lhs && rhs)
+    return native_wcscmp(lhs, rhs);
+  return 22;  // EINVAL
+}
+
+static int16_t* native_wcschr(const int16_t* str, int16_t ch) {
+  while (*str && *str != ch)
+    str++;
+
+  return (*str == ch) ? (int16_t*)str : 0;
+}
+
+static int16_t* native_wcsrchr(const int16_t* str, int16_t ch)
+{
+  const int16_t* res = 0;
+
+  for (; *str; str++)
+    if (*str == ch)
+        res = str;
+
+  return (int16_t*)(ch ? res : str);
+}
+
+static int16_t* native_wcscpy(const int16_t* src, int16_t* dst) {
+  int16_t* d = dst;
+
+  while ((*d++ = *src++))
+      ;
+
+  return dst;
+}
+
+static int16_t* native_wcsncpy(int16_t* dest, const int16_t* src, int count) {
+  int16_t* d = dest;
+  while (count-- && (*d++ = *src++))
+    ;
+  while (count--)
+    *d++ = 0;
+  return dest;
+}
+
+static int native_wcsncpy_s(int16_t* dst, size_t dstsz, const int16_t* src, size_t count) {
+  if (!dst || !src || dstsz == 0)
+    return 22;  // EINVAL
+
+  size_t i = 0;
+
+  for (; i < count && i + 1 < dstsz && src[i]; i++)
+    dst[i] = src[i];
+
+  if (i < dstsz)
+    dst[i] = 0;
+  else
+    dst[dstsz - 1] = 0;
+
+  if (i < count && src[i] != 0)
+    return 34;  // ERANGE
+
+  return 0;
+}
+
+int16_t* native_wcsstr(const int16_t* dest, const int16_t* src) {
+  if (!*src)
+    return (int16_t*)dest;
+
+  for (; *dest; dest++) {
+    const int16_t* d = dest;
+    const int16_t* s = src;
+
+    while (*d && *s && *d == *s) {
+      d++;
+      s++;
+    }
+
+    if (!*s)
+      return (int16_t*)dest;
+  }
+
+  return 0;
+}
+
 }  // namespace rex::kernel::crt
 
 REX_HOOK(rexcrt_strncmp, rex::kernel::crt::native_strncmp)
@@ -118,3 +231,13 @@ REX_HOOK(rexcrt_lstrcpyA, rex::kernel::crt::native_lstrcpyA)
 REX_HOOK(rexcrt_lstrcpynA, rex::kernel::crt::native_lstrcpynA)
 REX_HOOK(rexcrt_lstrcatA, rex::kernel::crt::native_lstrcatA)
 REX_HOOK(rexcrt_lstrcmpiA, rex::kernel::crt::native_lstrcmpiA)
+REX_HOOK(rexcrt_wcslen, rex::kernel::crt::native_wcslen)
+REX_HOOK(rexcrt_wcscmp, rex::kernel::crt::native_wcscmp)
+REX_HOOK(rexcrt_wcsncmp, rex::kernel::crt::native_wcsncmp)
+REX_HOOK(rexcrt_wcscoll, rex::kernel::crt::native_wcscoll)
+REX_HOOK(rexcrt_wcschr, rex::kernel::crt::native_wcschr)
+REX_HOOK(rexcrt_wcsrchr, rex::kernel::crt::native_wcsrchr)
+REX_HOOK(rexcrt_wcscpy, rex::kernel::crt::native_wcscpy)
+REX_HOOK(rexcrt_wcsncpy, rex::kernel::crt::native_wcsncpy)
+REX_HOOK(rexcrt_wcsncpy_s, rex::kernel::crt::native_wcsncpy_s)
+REX_HOOK(rexcrt_wcsstr, rex::kernel::crt::native_wcsstr)


### PR DESCRIPTION
## Summary

Adds support for Windows's C UTF-16 functions to rexcrt.
Unix uses UTF-32 for wchar_t and their wide string functions in the c standard library, as the C90 standard specifies, so providing manual implementations for these was needed.
For Windows it's completely fine using either the provided implementation from MSVC or to keep using the manual implementation.

## References
https://en.cppreference.com/w/c/header/wchar