### PR TITLE
Add more Message IDs in the XGI

### DIFF
--- a/src/kernel/xam/apps/xgi_app.cpp
+++ b/src/kernel/xam/apps/xgi_app.cpp
@@ -353,7 +353,7 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       uint32_t context_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
       auto context = context_ptr ? memory_->TranslateVirtual(context_ptr) : nullptr;
       uint32_t context_id = context ? memory::load_and_swap<uint32_t>(context + 0) : 0;
-      REXKRNL_DEBUG("XGIUserGetContext({:08X}, {:08X}{:08X}))", user_index, context_ptr,
+      REXKRNL_DEBUG("XGIUserGetContext({:08X}, {:08X}, {:08X}))", user_index, context_ptr,
                     context_id);
       uint32_t value = 0;
       if (context) {
@@ -373,7 +373,7 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       uint32_t reserved2 = memory::load_and_swap<uint32_t>(buffer + 24);
       uint32_t reserved3 = memory::load_and_swap<uint32_t>(buffer + 28);
 
-      REXKRNL_DEBUG("XSessionSearchByIds({:08X}, {:08X}, {:08X}, {:08X})", user_index,
+      REXKRNL_DEBUG("XSessionSearchByIds({:08X}, {:08X}, {:08X}, {:08X}, {:08X}, {}, {}, {})", user_index,
                     num_session_ids, session_ids_ptr, results_buffer_size, search_results_ptr,
                     reserved1, reserved2, reserved3);
 

--- a/src/kernel/xam/apps/xgi_app.cpp
+++ b/src/kernel/xam/apps/xgi_app.cpp
@@ -68,13 +68,13 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       // - XamSessionRefObjByHandle
       // - [this]
       // - CloseHandle
-      uint32_t session_ptr = memory::load_and_swap<uint32_t>(buffer + 0x0);
-      uint32_t flags = memory::load_and_swap<uint32_t>(buffer + 0x4);
-      uint32_t num_slots_public = memory::load_and_swap<uint32_t>(buffer + 0x8);
-      uint32_t num_slots_private = memory::load_and_swap<uint32_t>(buffer + 0xC);
-      uint32_t user_xuid = memory::load_and_swap<uint32_t>(buffer + 0x10);
-      uint32_t session_info_ptr = memory::load_and_swap<uint32_t>(buffer + 0x14);
-      uint32_t nonce_ptr = memory::load_and_swap<uint32_t>(buffer + 0x18);
+      uint32_t session_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t flags = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t num_slots_public = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t num_slots_private = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t user_xuid = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t session_info_ptr = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint32_t nonce_ptr = memory::load_and_swap<uint32_t>(buffer + 24);
 
       REXKRNL_DEBUG(
           "XGISessionCreateImpl({:08X}, {:08X}, {}, {}, {:08X}, {:08X}, "
@@ -84,17 +84,23 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       return X_E_SUCCESS;
     }
     case 0x000B0011: {
-      // TODO(PermaNull): reverse buffer contents.
-      REXKRNL_DEBUG("XGISessionDelete");
-      return X_STATUS_SUCCESS;
+      assert_true(!buffer_length || buffer_length == 16);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t flags = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint64_t session_nonce = memory::load_and_swap<uint64_t>(buffer + 8);
+
+      REXKRNL_DEBUG("XGISessionDelete({:08X}, {:08X}, {:016X})", obj_ptr, flags, session_nonce);
+
+      return X_E_SUCCESS;
     }
     case 0x000B0012: {
-      assert_true(buffer_length == 0x14);
-      uint32_t session_ptr = memory::load_and_swap<uint32_t>(buffer + 0x0);
-      uint32_t user_count = memory::load_and_swap<uint32_t>(buffer + 0x4);
-      uint32_t unk_0 = memory::load_and_swap<uint32_t>(buffer + 0x8);
-      uint32_t user_index_array = memory::load_and_swap<uint32_t>(buffer + 0xC);
-      uint32_t private_slots_array = memory::load_and_swap<uint32_t>(buffer + 0x10);
+      assert_true(!buffer_length || buffer_length == 20);
+      uint32_t session_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t user_count = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t unk_0 = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t user_index_array = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t private_slots_array = memory::load_and_swap<uint32_t>(buffer + 16);
 
       assert_zero(unk_0);
       REXKRNL_DEBUG("XGISessionJoinLocal({:08X}, {}, {}, {:08X}, {:08X})", session_ptr, user_count,
@@ -102,15 +108,243 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       return X_E_SUCCESS;
     }
     case 0x000B0014: {
-      // Gets 584107FB in game.
-      // get high score table?
-      REXKRNL_DEBUG("XGI_unknown");
+      assert_true(!buffer_length || buffer_length == 16);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t flags = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint64_t session_nonce = memory::load_and_swap<uint64_t>(buffer + 8);
+
+      REXKRNL_DEBUG("XSessionStart({:08X}, {:08X}, {:016X})", obj_ptr, flags, session_nonce);
+
       return X_STATUS_SUCCESS;
     }
     case 0x000B0015: {
       // send high scores?
-      REXKRNL_DEBUG("XGI_unknown");
-      return X_STATUS_SUCCESS;
+      assert_true(!buffer_length || buffer_length == 16);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t flags = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint64_t session_nonce = memory::load_and_swap<uint64_t>(buffer + 8);
+
+      REXKRNL_DEBUG("XSessionEnd({:08X}, {:08X}, {:016X})", obj_ptr, flags, session_nonce);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0016: {
+      assert_true(!buffer_length || buffer_length == 32);
+
+      uint32_t proc_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t num_results = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint16_t num_props = memory::load_and_swap<uint16_t>(buffer + 12);
+      uint16_t num_ctx = memory::load_and_swap<uint16_t>(buffer + 14);
+      uint32_t props_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t ctx_ptr = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint32_t results_buffer_size = memory::load_and_swap<uint32_t>(buffer + 24);
+      uint32_t search_results_ptr = memory::load_and_swap<uint32_t>(buffer + 28);
+
+      REXKRNL_DEBUG("XSessionSearch({}, {}, {}, {}, {}, {:08X}, {:08X}, {}, {:08X})", proc_index,
+                    user_index, num_results, num_props, num_ctx, props_ptr, ctx_ptr,
+                    results_buffer_size, search_results_ptr);
+      return X_E_SUCCESS;
+    }
+    case 0x000B0018: {
+      assert_true(!buffer_length || buffer_length == 16);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t flags = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t maxPublicSlots = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint16_t maxPrivateSlots = memory::load_and_swap<uint16_t>(buffer + 12);
+
+      REXKRNL_DEBUG("XSessionModify({:08X}, {:08X}, {:08X}, {:08X})", obj_ptr, flags,
+                    maxPublicSlots, maxPrivateSlots);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B001C: {
+      assert_true(!buffer_length || buffer_length == 36);
+
+      // session_search
+      uint32_t proc_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t num_results = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint16_t num_props = memory::load_and_swap<uint16_t>(buffer + 12);
+      uint16_t num_ctx = memory::load_and_swap<uint16_t>(buffer + 14);
+      uint32_t props_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t ctx_ptr = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint32_t results_buffer_size = memory::load_and_swap<uint32_t>(buffer + 24);
+      uint32_t search_results_ptr = memory::load_and_swap<uint32_t>(buffer + 28);
+      //
+      uint32_t num_users = memory::load_and_swap<uint32_t>(buffer + 32);
+
+      REXKRNL_DEBUG("XSessionSearchEx({}, {}, {}, {}, {}, {:08X}, {:08X}, {}, {:08X}, {})",
+                    proc_index, user_index, num_results, num_props, num_ctx, props_ptr, ctx_ptr,
+                    results_buffer_size, search_results_ptr, num_users);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B001D: {
+      assert_true(!buffer_length || buffer_length == 24);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t details_buffer_size = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t session_details_ptr = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t reserved1 = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t reserved2 = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t reserved3 = memory::load_and_swap<uint32_t>(buffer + 20);
+
+      REXKRNL_DEBUG("XSessionGetDetails({:08X}, {}, {:08X}, {}, {}, {})", obj_ptr,
+                    details_buffer_size, session_details_ptr, reserved1, reserved2, reserved3);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B001E: {
+      assert_true(!buffer_length || buffer_length == 24);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t session_info_ptr = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t reserved1 = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t reserved2 = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t reserved3 = memory::load_and_swap<uint32_t>(buffer + 20);
+
+      REXKRNL_DEBUG("XSessionMigrateHost({:08X}, {:08X}, {}, {}, {}, {})", obj_ptr,
+                    session_info_ptr, user_index, reserved1, reserved2, reserved3);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0019: {
+      assert_true(!buffer_length || buffer_length == 8);
+
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t session_info_ptr = memory::load_and_swap<uint32_t>(buffer + 4);
+
+      REXKRNL_DEBUG("XSessionGetInvitationData - unimplemented({}, {:08X})", user_index,
+                    session_info_ptr);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B001A: {
+      assert_true(!buffer_length || buffer_length == 28);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t flags = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint64_t session_nonce = memory::load_and_swap<uint64_t>(buffer + 8);
+      uint32_t session_duration_sec = memory::load_and_swap<uint32_t>(buffer + 16);  // 300
+      uint32_t results_buffer_size = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint32_t results_ptr = memory::load_and_swap<uint32_t>(buffer + 24);
+
+      REXKRNL_DEBUG("XSessionArbitrationRegister({:08X}, {:08X}, {:016X}, {:08X}, {:08X}, {:08X})",
+                    obj_ptr, flags, session_nonce, session_duration_sec, results_buffer_size,
+                    results_ptr);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B001B: {
+      assert_true(!buffer_length || buffer_length == 32);
+
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t num_session_ids = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t session_ids_ptr = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t results_buffer_size = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t search_results_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t reserved1 = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint32_t reserved2 = memory::load_and_swap<uint32_t>(buffer + 24);
+      uint32_t reserved3 = memory::load_and_swap<uint32_t>(buffer + 28);
+
+      REXKRNL_DEBUG("XSessionSearchByID({}, {:08X}, {:08X}, {:08X}, {:08X}, {}, {}, {})",
+                    user_index, num_session_ids, session_ids_ptr, results_buffer_size,
+                    search_results_ptr, reserved1, reserved2, reserved3);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B001F: {
+      assert_true(!buffer_length || buffer_length == 24);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t array_count = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t xuid_array_ptr = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t reserved1 = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t reserved2 = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t reserved3 = memory::load_and_swap<uint32_t>(buffer + 20);
+
+      REXKRNL_DEBUG("XSessionModifySkill({:08X}, {}, {:08X}, {}, {}, {})", obj_ptr, array_count,
+                    xuid_array_ptr, reserved1, reserved2, reserved3);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0020: {
+      assert_true(!buffer_length || buffer_length == 8);
+
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t view_id = memory::load_and_swap<uint32_t>(buffer + 4);
+
+      REXKRNL_DEBUG("XUserResetStatsView({:08X}, {})", user_index, view_id);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0021: {
+      assert_true(!buffer_length || buffer_length == 28);
+
+      uint32_t title_id = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t xuids_count = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t xuids_ptr = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t specs_count = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t specs_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t results_size = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint32_t results_ptr = memory::load_and_swap<uint32_t>(buffer + 24);
+
+      REXKRNL_DEBUG("XUserReadStats({}, {}, {:08X}, {}, {:08X}, {}, {:08X})", title_id, xuids_count,
+                    xuids_ptr, specs_count, specs_ptr, results_size, results_ptr);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0025: {
+      assert_true(!buffer_length || buffer_length == 20);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint64_t xuid = memory::load_and_swap<uint64_t>(buffer + 4);
+      uint32_t num_views = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t views_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+
+      REXKRNL_DEBUG("XSessionWriteStats({:08X}, {:016X}, {:08X}, {:08X})", obj_ptr, xuid, num_views,
+                    views_ptr);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0026: {
+      assert_true(!buffer_length || buffer_length == 20);
+
+      uint32_t obj_ptr = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint64_t xuid = memory::load_and_swap<uint64_t>(buffer + 4);
+      uint32_t num_views = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t views_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+
+      REXKRNL_DEBUG("XSessionFlushStats({:08X}, {:016X}, {:08X}, {:08X})", obj_ptr, xuid, num_views,
+                    views_ptr);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0036: {
+      // Called after opening xbox live arcade and clicking on xbox live v5759
+      // to 5787 and called after clicking xbox live in the game library from
+      // v6683 to v6717
+      // Does not get sent a buffer
+      REXKRNL_DEBUG("XInvalidateGamerTileCache, unimplemented");
+      return X_E_FAIL;
+    }
+    case 0x000B003D: {
+      assert_true(!buffer_length || buffer_length == 16);
+
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t AnId_buffer_size = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t AnId_buffer_ptr = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t block = memory::load_and_swap<uint32_t>(buffer + 12);
+
+      REXKRNL_DEBUG("XUserGetANID({:08X}, {:08X}, {:08X}, {:08X})", user_index, AnId_buffer_size,
+                    AnId_buffer_ptr, block);
+
+      return X_E_SUCCESS;
     }
     case 0x000B0041: {
       assert_true(!buffer_length || buffer_length == 32);
@@ -126,6 +360,53 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
         memory::store_and_swap<uint32_t>(context + 4, value);
       }
       return X_E_FAIL;
+    }
+    case 0x000B0060: {
+      assert_true(!buffer_length || buffer_length == 32);
+
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t num_session_ids = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t session_ids_ptr = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint32_t results_buffer_size = memory::load_and_swap<uint32_t>(buffer + 12);
+      uint32_t search_results_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t reserved1 = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint32_t reserved2 = memory::load_and_swap<uint32_t>(buffer + 24);
+      uint32_t reserved3 = memory::load_and_swap<uint32_t>(buffer + 28);
+
+      REXKRNL_DEBUG("XSessionSearchByIds({:08X}, {:08X}, {:08X}, {:08X})", user_index,
+                    num_session_ids, session_ids_ptr, results_buffer_size, search_results_ptr,
+                    reserved1, reserved2, reserved3);
+
+      return X_E_SUCCESS;
+    }
+    case 0x000B0065: {
+      assert_true(!buffer_length || buffer_length == 52);
+
+      uint32_t proc_index = memory::load_and_swap<uint32_t>(buffer + 0);
+      uint32_t user_index = memory::load_and_swap<uint32_t>(buffer + 4);
+      uint32_t num_results = memory::load_and_swap<uint32_t>(buffer + 8);
+      uint16_t num_weighted_properties = memory::load_and_swap<uint16_t>(buffer + 12);
+      uint16_t num_weighted_contexts = memory::load_and_swap<uint16_t>(buffer + 14);
+      uint32_t weighted_search_properties_ptr = memory::load_and_swap<uint32_t>(buffer + 16);
+      uint32_t weighted_search_contexts_ptr = memory::load_and_swap<uint32_t>(buffer + 20);
+      uint16_t num_props = memory::load_and_swap<uint16_t>(buffer + 24);
+      uint16_t num_ctx = memory::load_and_swap<uint16_t>(buffer + 26);
+      uint32_t non_weighted_search_properties_ptr = memory::load_and_swap<uint32_t>(buffer + 28);
+      uint32_t non_weighted_search_contexts_ptr = memory::load_and_swap<uint32_t>(buffer + 32);
+      uint32_t results_buffer_size = memory::load_and_swap<uint32_t>(buffer + 36);
+      uint32_t search_results_ptr = memory::load_and_swap<uint32_t>(buffer + 40);
+      uint32_t num_users = memory::load_and_swap<uint32_t>(buffer + 44);
+      uint32_t weighted_search = memory::load_and_swap<uint32_t>(buffer + 48);
+
+      REXKRNL_DEBUG(
+          "XSessionSearchWeighted({:08X}, {:08X}, {:08X}, {}, {}, {:08X}, {:08X}, {}, {}, {:08X}, "
+          "{:08X}, {:08X}, {:08X}, {:08X}, {:08X})",
+          proc_index, user_index, num_results, num_weighted_properties, num_weighted_contexts,
+          weighted_search_properties_ptr, weighted_search_contexts_ptr, num_props, num_ctx,
+          non_weighted_search_properties_ptr, non_weighted_search_contexts_ptr, results_buffer_size,
+          search_results_ptr, num_users, weighted_search);
+
+      return X_E_SUCCESS;
     }
     case 0x000B0071: {
       REXKRNL_DEBUG("XGI 0x000B0071, unimplemented");


### PR DESCRIPTION
### Summary
When testing out a game on my end, I noticed some messages were undocumented in the switch case of xgi_app.cpp, so I added:
XGISessionDelete, XSessionStart, XSessionEnd, XSessionSearch, XSessionModify, XSessionSearchEx, XSessionGetDetails, XSessionMigrateHost, XSessionGetInvitationData, XSessionArbitrationRegister, XSessionSearchByID, XSessionModifySkill, XUserResetStatsView, "XUserReadStats, XSessionWriteStats, XSessionFlushStats, XInvalidateGamerTileCache, & XUserGetANID