### PR TITLE
feat(app): add hook for adding log sinks

### DIFF
--- a/include/rex/rex_app.h
+++ b/include/rex/rex_app.h
@@ -102,6 +102,9 @@ class ReXApp : public ui::WindowedApp, public ui::WindowListener, public ui::Win
   /// Override to adjust game/user/update data paths programmatically.
   virtual void OnConfigurePaths(PathConfig& paths) { (void)paths; }
 
+  /// Called after logging is initialized. Add log sinks here.
+  virtual void OnPostInitLogging() {}
+
   /// Called after Runtime::LoadXexImage() succeeds. The XEX is loaded and
   /// mapped into guest memory but the module has not launched.
   /// Use this for data patches on the loaded image.

--- a/resources/templates/init/app_header.inja
+++ b/resources/templates/init/app_header.inja
@@ -18,6 +18,7 @@ class {{ names.pascal_case }}App : public rex::ReXApp {
   }
 
   // Override virtual hooks for customization:
+  // void OnPostInitLogging() override {}
   // void OnPreSetup(rex::RuntimeConfig& config) override {}
   // void OnLoadXexImage(std::string& xex_image) override {}
   // void OnPostSetup() override {}

--- a/src/ui/rex_app.cpp
+++ b/src/ui/rex_app.cpp
@@ -126,6 +126,8 @@ bool ReXApp::OnInitialize() {
   log_sink_ = std::make_shared<rex::LogCaptureSink>();
   rex::AddSink(log_sink_);
 
+  OnPostInitLogging();
+
   if (std::filesystem::exists(config_path))
     REXLOG_INFO("Loaded config: {}", config_path.filename().string());
 


### PR DESCRIPTION
Adds an overrideable hook OnPostInitLogging which is called right after logging is initialized, to allow for adding log sinks which will receive even the earliest log messages. Takes care of #292.