### PR TITLE
refactor(system): migrate from legacy move_only functions

### DIFF
--- a/include/rex/system/kernel_state.h
+++ b/include/rex/system/kernel_state.h
@@ -285,24 +285,23 @@ class KernelState {
   void CompleteOverlappedImmediateEx(uint32_t overlapped_ptr, X_RESULT result,
                                      uint32_t extended_error, uint32_t length);
 
-  void CompleteOverlappedDeferred(std::move_only_function<void()> completion_callback,
+  void CompleteOverlappedDeferred(std::function<void()> completion_callback,
                                   uint32_t overlapped_ptr, X_RESULT result,
-                                  std::move_only_function<void()> pre_callback = nullptr,
-                                  std::move_only_function<void()> post_callback = nullptr);
-  void CompleteOverlappedDeferredEx(std::move_only_function<void()> completion_callback,
+                                  std::function<void()> pre_callback = nullptr,
+                                  std::function<void()> post_callback = nullptr);
+  void CompleteOverlappedDeferredEx(std::function<void()> completion_callback,
                                     uint32_t overlapped_ptr, X_RESULT result,
                                     uint32_t extended_error, uint32_t length,
-                                    std::move_only_function<void()> pre_callback = nullptr,
-                                    std::move_only_function<void()> post_callback = nullptr);
+                                    std::function<void()> pre_callback = nullptr,
+                                    std::function<void()> post_callback = nullptr);
 
-  void CompleteOverlappedDeferred(std::move_only_function<X_RESULT()> completion_callback,
+  void CompleteOverlappedDeferred(std::function<X_RESULT()> completion_callback,
                                   uint32_t overlapped_ptr,
-                                  std::move_only_function<void()> pre_callback = nullptr,
-                                  std::move_only_function<void()> post_callback = nullptr);
+                                  std::function<void()> pre_callback = nullptr,
+                                  std::function<void()> post_callback = nullptr);
   void CompleteOverlappedDeferredEx(
-      std::move_only_function<X_RESULT(uint32_t&, uint32_t&)> completion_callback,
-      uint32_t overlapped_ptr, std::move_only_function<void()> pre_callback = nullptr,
-      std::move_only_function<void()> post_callback = nullptr);
+      std::function<X_RESULT(uint32_t&, uint32_t&)> completion_callback, uint32_t overlapped_ptr,
+      std::function<void()> pre_callback = nullptr, std::function<void()> post_callback = nullptr);
 
   bool Save(stream::ByteStream* stream);
   bool Restore(stream::ByteStream* stream);
@@ -352,7 +351,7 @@ class KernelState {
   // Must be guarded by the global critical region.
   util::NativeList dpc_list_;
   std::condition_variable_any dispatch_cond_;
-  std::list<std::move_only_function<void()>> dispatch_queue_;
+  std::list<std::function<void()>> dispatch_queue_;
 
   friend class XObject;
 };

--- a/include/rex/thread/timer_queue.h
+++ b/include/rex/thread/timer_queue.h
@@ -26,8 +26,8 @@ class TimerQueue;
 struct TimerQueueWaitItem {
   using clock = std::chrono::steady_clock;
 
-  TimerQueueWaitItem(std::move_only_function<void(void*)> callback, void* userdata,
-                     TimerQueue* parent_queue, clock::time_point due, clock::duration interval)
+  TimerQueueWaitItem(std::function<void(void*)> callback, void* userdata, TimerQueue* parent_queue,
+                     clock::time_point due, clock::duration interval)
       : callback_(std::move(callback)),
         userdata_(userdata),
         parent_queue_(parent_queue),
@@ -55,7 +55,7 @@ struct TimerQueueWaitItem {
   };
   static_assert(std::atomic<State>::is_always_lock_free);
 
-  std::move_only_function<void(void*)> callback_;
+  std::function<void(void*)> callback_;
   void* userdata_;
   TimerQueue* parent_queue_;
   clock::time_point due_;
@@ -63,14 +63,14 @@ struct TimerQueueWaitItem {
   std::atomic<State> state_;
 };
 
-std::weak_ptr<TimerQueueWaitItem> QueueTimerOnce(std::move_only_function<void(void*)> callback,
+std::weak_ptr<TimerQueueWaitItem> QueueTimerOnce(std::function<void(void*)> callback,
                                                  void* userdata,
                                                  TimerQueueWaitItem::clock::time_point due);
 
 // Callback is first executed at due, then again repeatedly after interval
 // passes (unless interval == 0). The first callback will be scheduled at
 // `max(now() - interval, due)` to mitigate callback flooding.
-std::weak_ptr<TimerQueueWaitItem> QueueTimerRecurring(std::move_only_function<void(void*)> callback,
+std::weak_ptr<TimerQueueWaitItem> QueueTimerRecurring(std::function<void(void*)> callback,
                                                       void* userdata,
                                                       TimerQueueWaitItem::clock::time_point due,
                                                       TimerQueueWaitItem::clock::duration interval);

--- a/src/core/timer_queue.cpp
+++ b/src/core/timer_queue.cpp
@@ -187,14 +187,14 @@ void TimerQueueWaitItem::Disarm() {
   }
 }
 
-std::weak_ptr<WaitItem> QueueTimerOnce(std::move_only_function<void(void*)> callback,
-                                       void* userdata, WaitItem::clock::time_point due) {
+std::weak_ptr<WaitItem> QueueTimerOnce(std::function<void(void*)> callback, void* userdata,
+                                       WaitItem::clock::time_point due) {
   return timer_queue_.QueueTimer(std::make_shared<WaitItem>(
       std::move(callback), userdata, &timer_queue_, due, WaitItem::clock::duration::zero()));
 }
 
-std::weak_ptr<WaitItem> QueueTimerRecurring(std::move_only_function<void(void*)> callback,
-                                            void* userdata, WaitItem::clock::time_point due,
+std::weak_ptr<WaitItem> QueueTimerRecurring(std::function<void(void*)> callback, void* userdata,
+                                            WaitItem::clock::time_point due,
                                             WaitItem::clock::duration interval) {
   return timer_queue_.QueueTimer(
       std::make_shared<WaitItem>(std::move(callback), userdata, &timer_queue_, due, interval));

--- a/src/system/kernel_state.cpp
+++ b/src/system/kernel_state.cpp
@@ -856,56 +856,54 @@ void KernelState::CompleteOverlappedImmediateEx(uint32_t overlapped_ptr, X_RESUL
   CompleteOverlappedEx(overlapped_ptr, result, extended_error, length);
 }
 
-void KernelState::CompleteOverlappedDeferred(std::move_only_function<void()> completion_callback,
+void KernelState::CompleteOverlappedDeferred(std::function<void()> completion_callback,
                                              uint32_t overlapped_ptr, X_RESULT result,
-                                             std::move_only_function<void()> pre_callback,
-                                             std::move_only_function<void()> post_callback) {
+                                             std::function<void()> pre_callback,
+                                             std::function<void()> post_callback) {
   CompleteOverlappedDeferredEx(std::move(completion_callback), overlapped_ptr, result, result, 0,
-                               std::move(pre_callback), std::move(post_callback));
+                               pre_callback, post_callback);
 }
 
-void KernelState::CompleteOverlappedDeferredEx(std::move_only_function<void()> completion_callback,
+void KernelState::CompleteOverlappedDeferredEx(std::function<void()> completion_callback,
                                                uint32_t overlapped_ptr, X_RESULT result,
                                                uint32_t extended_error, uint32_t length,
-                                               std::move_only_function<void()> pre_callback,
-                                               std::move_only_function<void()> post_callback) {
+                                               std::function<void()> pre_callback,
+                                               std::function<void()> post_callback) {
   CompleteOverlappedDeferredEx(
-      [completion_callback = std::move(completion_callback), result, extended_error, length](
-          uint32_t& cb_extended_error, uint32_t& cb_length) mutable -> X_RESULT {
+      [completion_callback, result, extended_error, length](uint32_t& cb_extended_error,
+                                                            uint32_t& cb_length) -> X_RESULT {
         completion_callback();
         cb_extended_error = extended_error;
         cb_length = length;
         return result;
       },
-      overlapped_ptr, std::move(pre_callback), std::move(post_callback));
+      overlapped_ptr, pre_callback, post_callback);
 }
 
-void KernelState::CompleteOverlappedDeferred(
-    std::move_only_function<X_RESULT()> completion_callback, uint32_t overlapped_ptr,
-    std::move_only_function<void()> pre_callback, std::move_only_function<void()> post_callback) {
+void KernelState::CompleteOverlappedDeferred(std::function<X_RESULT()> completion_callback,
+                                             uint32_t overlapped_ptr,
+                                             std::function<void()> pre_callback,
+                                             std::function<void()> post_callback) {
   CompleteOverlappedDeferredEx(
-      [completion_callback = std::move(completion_callback)](uint32_t& extended_error,
-                                                             uint32_t& length) mutable -> X_RESULT {
+      [completion_callback](uint32_t& extended_error, uint32_t& length) -> X_RESULT {
         auto result = completion_callback();
         extended_error = static_cast<uint32_t>(result);
         length = 0;
         return result;
       },
-      overlapped_ptr, std::move(pre_callback), std::move(post_callback));
+      overlapped_ptr, pre_callback, post_callback);
 }
 
 void KernelState::CompleteOverlappedDeferredEx(
-    std::move_only_function<X_RESULT(uint32_t&, uint32_t&)> completion_callback,
-    uint32_t overlapped_ptr, std::move_only_function<void()> pre_callback,
-    std::move_only_function<void()> post_callback) {
+    std::function<X_RESULT(uint32_t&, uint32_t&)> completion_callback, uint32_t overlapped_ptr,
+    std::function<void()> pre_callback, std::function<void()> post_callback) {
   REXSYS_DEBUG("CompleteOverlappedDeferredEx: queuing for overlapped {:08X}", overlapped_ptr);
   auto ptr = memory()->TranslateVirtual(overlapped_ptr);
   XOverlappedSetResult(ptr, X_ERROR_IO_PENDING);
   XOverlappedSetContext(ptr, XThread::GetCurrentThreadHandle());
   auto global_lock = global_critical_region_.Acquire();
   dispatch_queue_.push_back(
-      [this, overlapped_ptr, completion_callback = std::move(completion_callback),
-       pre_callback = std::move(pre_callback), post_callback = std::move(post_callback)]() mutable {
+      [this, completion_callback, overlapped_ptr, pre_callback, post_callback]() {
         REXSYS_DEBUG("Deferred overlapped {:08X}: running pre_callback", overlapped_ptr);
         if (pre_callback) {
           pre_callback();

--- a/thirdparty/disruptorplus/include/disruptorplus/multi_threaded_claim_strategy.hpp
+++ b/thirdparty/disruptorplus/include/disruptorplus/multi_threaded_claim_strategy.hpp
@@ -312,7 +312,7 @@ namespace disruptorplus
                         return false;
                     }
                 }
-                reducedCount = std::min(count, static_cast<sequence_t>(diff + 1));
+                reducedCount = std::min(count, static_cast<size_t>(diff + 1));
             } while (!m_nextClaimable.compare_exchange_weak(
                 sequence,
                 static_cast<sequence_t>(sequence + reducedCount),


### PR DESCRIPTION
Pulled from xenia-edge, mainly for weird systems who don't supply this function automatically cough mac
https://github.com/has207/xenia-edge/blob/edge/src/xenia/base/threading_timer_queue.h/#L28