### PR TITLE
Fix: always mask SSE exceptions in FPSCRPlatform::setcsr (Linux SIGFPE)

### DIFF
--- a/include/rex/platform/fpscr.h
+++ b/include/rex/platform/fpscr.h
@@ -43,7 +43,7 @@ struct FPSCRPlatform {
 
   static inline u32 getcsr() noexcept { return simde_mm_getcsr(); }
 
-  static inline void setcsr(u32 csr) noexcept { simde_mm_setcsr(csr); }
+  static inline void setcsr(u32 csr) noexcept { simde_mm_setcsr(csr | ExceptionMask); }
 
   static inline void InitHostExceptions(u32& csr) noexcept {
     csr |= ExceptionMask;  // Set mask bits to disable exceptions


### PR DESCRIPTION
## Problem

`InitHostExceptions` sets SSE exception mask bits at startup, but PPC
FPSCR values written at runtime translate directly to `ldmxcsr` with the
guest value, which can clear those mask bits and re-enable SSE exceptions.
On Linux this causes a `SIGFPE`. Windows is unaffected because SEH handles
floating-point exceptions transparently.

`setcsr` is called on every PPC FPSCR write from recompiled guest code, so
the exception mask is clobbered at high frequency during normal execution.

## Fix

OR `ExceptionMask` unconditionally in `setcsr` (x86_64 branch only), so
SSE exceptions remain masked for the lifetime of the process regardless of
what the PPC guest writes to FPSCR.

The ARM64 branch does not need this change. `InitHostExceptions` clears
exception enable bits there (ARM FPCR: 0 = disabled), and PPC FPSCR writes
do not map to ARM exception-enable bits in the same way.
