### PR TITLE
fix(build): require Linux audio backends

### DIFF
--- a/.github/workflows/_build-platform.yaml
+++ b/.github/workflows/_build-platform.yaml
@@ -61,14 +61,16 @@ jobs:
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev wine vulkan-sdk
+            libgtk-3-dev libx11-xcb-dev wine vulkan-sdk \
+            libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Install build deps (linux-arm64)
         if: inputs.platform == 'linux-arm64'
         run: |
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev libvulkan-dev glslc glslang-tools
+            libgtk-3-dev libx11-xcb-dev libvulkan-dev glslc glslang-tools \
+            libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Set up sccache
         uses: hendrikmuhs/ccache-action@v1.2.22

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -260,6 +260,16 @@ set(SDL_DISKAUDIO OFF CACHE BOOL "" FORCE)
 set(SDL_DUMMYAUDIO OFF CACHE BOOL "" FORCE)
 set(SDL_DUMMYVIDEO OFF CACHE BOOL "" FORCE)
 
+# Linux audio backends
+if(UNIX AND NOT APPLE)
+    set(SDL_ALSA              ON  CACHE BOOL "" FORCE)
+    set(SDL_ALSA_SHARED       ON  CACHE BOOL "" FORCE)
+    set(SDL_PULSEAUDIO        ON  CACHE BOOL "" FORCE)
+    set(SDL_PULSEAUDIO_SHARED ON  CACHE BOOL "" FORCE)
+    set(SDL_PIPEWIRE          ON  CACHE BOOL "" FORCE)
+    set(SDL_PIPEWIRE_SHARED   ON  CACHE BOOL "" FORCE)
+endif()
+
 add_subdirectory(sdl3)
 
 #=============================================================================


### PR DESCRIPTION
Linux builds fail to start with the following error:
`[error] [apu] [t10020] SDL_InitSubSystem(SDL_INIT_AUDIO) failed: No available audio device`

The only way to fix it is starting the program with the `SDL_AUDIODRIVER` env variable set to `dummy`.
This happens because some dependencies are not present while SDL3 is being built, so the audio backends do not get compiled in.

This PR adds them into the build workflow and also sets them as required in `CMakeLists.txt` so that the build will fail loudly if the dependencies are ever missing again.