### PR TITLE
fix(codegen): build_dcbz must clear 128 bytes (Xenon cache line)

### DIFF
--- a/src/codegen/builders/system.cpp
+++ b/src/codegen/builders/system.cpp
@@ -148,12 +148,28 @@ bool build_dcbtst(BuilderContext& ctx) {
 }
 
 bool build_dcbz(BuilderContext& ctx) {
-  // Compute EA, align to 32-byte cache line, apply physical offset
+  // FIX: Xbox 360's Xenon CPU has 128-byte L1 cache lines, NOT 32-byte.
+  // The Xenon's PowerPC variant always treats `dcbz` as clearing one full
+  // 128-byte cache line (architecturally allowed: PPC mandates dcbz uses
+  // the implementation cache-line size, and Xenon defines 128 bytes).
+  // Compilers targeting the Xenon toolchain emit dcbz expecting 128-byte
+  // clears, often as part of fast object-zero or constructor paths. With
+  // the previous 32-byte impl, only the first 32 of every 128-byte line
+  // got cleared, leaving stale heap bytes (e.g., recycled vtable slots)
+  // that cause downstream null-vtable cascades.
+  //
+  // Symptom this fix addresses (Final Exam): a freshly-allocated 0x4408xxxx
+  // bank object has its vtable bytes 32+ in length not zeroed, so when
+  // the constructor proceeds and only writes some fields, the reads of
+  // unzeroed slots return non-zero garbage in some cases or zero in others
+  // depending on prior heap content.
+  //
+  // Now identical to dcbzl: clears 128 bytes aligned to 128.
   ctx.print("\t{} = (", ctx.ea());
   if (ctx.insn.operands[0] != 0)
     ctx.print("{}.u32 + ", ctx.r(ctx.insn.operands[0]));
-  ctx.println("{}.u32) & ~31;", ctx.r(ctx.insn.operands[1]));
-  ctx.println("\tmemset((void*)REX_RAW_ADDR({}), 0, 32);", ctx.ea());
+  ctx.println("{}.u32) & ~127;", ctx.r(ctx.insn.operands[1]));
+  ctx.println("\tmemset((void*)REX_RAW_ADDR({}), 0, 128);", ctx.ea());
   return true;
 }
 


### PR DESCRIPTION
Fixes #313

## Summary

Fixes `build_dcbz` in `src/codegen/builders/system.cpp` to use 128-byte cache lines (Xenon CPU's actual L1 cache line size) instead of 32-byte. Brings it in line with the already-correct `build_dcbzl` builder.

## The bug

Xbox 360's Xenon PowerPC variant has **128-byte L1 cache lines**, not 32-byte. The PowerPC architecture mandates that `dcbz` operate on the implementation's cache-line size — Xenon defines this as 128 bytes (per the Xenon Reference Manual / IBM CBE technical docs).

Before this fix, the codegen emitted `dcbz` as a 32-byte memset. The Xenon toolchain compiler (Xenon GCC / XDK CL) emits `dcbz` expecting 128-byte clears, typically as fast object-zero in `operator new` and constructor preludes. With only the first 32 bytes cleared per cache line, the remaining 96 bytes retained stale heap content from prior allocations.

The asymmetry was already self-evident: `build_dcbzl` (the architecturally-explicit 128-byte form) at `src/codegen/builders/system.cpp:160-168` is implemented as 128-byte. `build_dcbz` was the inconsistent one.

## Fix

Change `build_dcbz` to use `& ~127` alignment and `memset(..., 0, 128)`, identical to `build_dcbzl`.

## Symptom we hit

In a downstream port (Final Exam — Mighty Rocket Studio, 2014, Xbox 360 XBLA), a freshly-allocated resource-bank object had its vtable slot read as non-zero garbage in 96 of every 128 bytes. The 32-byte `dcbz` left those bytes containing previous heap content. The constructor that ran after `dcbz` only initialized some fields, so subsequent reads of "un-initialized" fields produced non-zero values. Indirect-call dispatches through the corrupted vtable slot then failed with `ctr=0` ("Indirect call to out-of-range guest address 00000000").

## Compatibility

- ✅ Skate 3: tested, no regression. Skate 3's emitted `dcbz` count is small.
- ✅ `dcbzl` was already 128-byte; this just brings `dcbz` in line.
- ✅ Compatible with the AccessViolationCallback's existing 128-byte cache-line assumptions.
- No API changes, no cvar changes.

## Reviewer checklist

- [ ] Code review of changes in `src/codegen/builders/system.cpp`
- [ ] Verify Xenon ref manual cache-line size (128 B)
- [ ] Test with at least one title to confirm no regression

## References

- Xenon CBE technical reference: 128 B L1 cache line
- xenia-canary's `xenia/cpu/ppc/ppc_emit_memory.cc` uses 128 for dcbz
- File:line of the asymmetry: `src/codegen/builders/system.cpp:150-158` (dcbz, was 32B) vs `src/codegen/builders/system.cpp:160-168` (dcbzl, was already 128B)