### PR TITLE
fix(system): select function table heap by load address

### DIFF
--- a/src/system/xmemory.cpp
+++ b/src/system/xmemory.cpp
@@ -725,13 +725,26 @@ bool Memory::InitializeFunctionTable(uint32_t code_base, uint32_t code_size, uin
       "(+{:08X} thunk reserve)",
       function_table_base_, table_size, code_base, code_base + code_size, kThunkReserveSize);
 
-  // Allocate the function table region in guest memory.
-  // Use the 64k page heap (v80000000) since that's where XEX code lives.
-  if (!heaps_.v80000000.AllocFixed(
-          function_table_base_, table_size, 0x10000,
+  // Allocate the function table region in guest memory. The XEX guest
+  // address layout uses two heaps for code: v80000000 (64KB pages, e.g.
+  // 0x82000000-base XBLA titles) and v90000000 (4KB pages, e.g. Hexic HD's
+  // 0x92000000 base). Hardcoding v80000000 fails for the latter with
+  // "BaseHeap::AllocFixed invalid base alignment". Look up the right heap
+  // dynamically and use its declared page_size() for alignment.
+  BaseHeap* table_heap = LookupHeap(function_table_base_);
+  if (!table_heap) {
+    REXSYS_ERROR("No heap covers function_table_base={:08X}", function_table_base_);
+    function_table_base_ = 0;
+    return false;
+  }
+  uint32_t table_alignment = table_heap->page_size();
+  if (!table_heap->AllocFixed(
+          function_table_base_, table_size, table_alignment,
           memory::kMemoryAllocationReserve | memory::kMemoryAllocationCommit,
           memory::kMemoryProtectRead | memory::kMemoryProtectWrite)) {
-    REXSYS_ERROR("Failed to allocate function table at {:08X}", function_table_base_);
+    REXSYS_ERROR("Failed to allocate function table at {:08X} (heap={:08X}-{:08X}, align={:X})",
+                 function_table_base_, table_heap->heap_base(),
+                 table_heap->heap_base() + table_heap->heap_size(), table_alignment);
     function_table_base_ = 0;
     return false;
   }


### PR DESCRIPTION
Fixes #314

## Summary

`Memory::InitializeFunctionTable` hardcoded `heaps_.v80000000` for the function table allocation. This works for typical XBLA titles loading at `0x82000000` (v80000000 heap, 64KB pages) but fails for titles that load at `0x92000000+` (v90000000 heap, 4KB pages) — e.g., Hexic HD, preinstalled on every original Xbox 360.

For an XEX with image base `0x92000000` and image size `0x2A5000`, the computed `function_table_base = 0x922A5000` lies in the v90000000 range, but the hardcoded v80000000 only covers `0x80000000-0x8FFFFFFF`. `BaseHeap::AllocFixed` correctly rejects:

```
BaseHeap::AllocFixed invalid base alignment: base=922A5000 page_size=00010000 requested_alignment=00010000 heap=80000000-8FFFFFFF
```

and the SDK aborts with `C0000001` before the title runs.

## Change

```cpp
BaseHeap* table_heap = LookupHeap(function_table_base_);
if (!table_heap) {
  REXSYS_ERROR("No heap covers function_table_base={:08X}", function_table_base_);
  function_table_base_ = 0;
  return false;
}
uint32_t table_alignment = table_heap->page_size();
if (!table_heap->AllocFixed(function_table_base_, table_size, table_alignment, ...)) {
  ...
}
```

`Memory::LookupHeap(uint32_t)` already exists in `xmemory.cpp` and returns the heap covering a guest address; `BaseHeap::page_size()` returns the heap's natural page size (declared at `xmemory.h:143`). Both APIs are used elsewhere in the SDK.

## Behavior

- `0x82xxxxxx` titles: `LookupHeap` returns `&heaps_.v80000000` (initialized with 64KB pages at `xmemory.cpp:171`), `page_size() == 0x10000` — identical to the previous hardcoded path.
- `0x92xxxxxx` titles (Hexic HD): `LookupHeap` returns `&heaps_.v90000000` (initialized with 4KB pages at `xmemory.cpp:173`), `page_size() == 0x1000` — alignment matches the heap's actual page size.

## Verification

- Build: `rexsystem` builds clean against current `development` (no new warnings beyond pre-existing).
- For 64KB-page titles, the call sequence and arguments are unchanged in effect (heap, alignment, allocation flags all identical to the previous `heaps_.v80000000.AllocFixed(..., 0x10000, ...)`).
- For 4KB-page titles, the AllocFixed call now hits `v90000000` with 4KB alignment; previously the SDK aborted before reaching this point.
