### PR TITLE
fix(codegen): handle backward `b` to target inside another known function

### DIFF
--- a/src/codegen/builders/control_flow.cpp
+++ b/src/codegen/builders/control_flow.cpp
@@ -48,6 +48,21 @@ bool build_b(BuilderContext& ctx) {
       // Unknown target - fall back to range check
       if (target >= ctx.fn.base() && target < ctx.fn.end()) {
         ctx.println("\tgoto loc_{:X};", target);
+      } else if (const auto* containingFn = ctx.graph().getFunctionContaining(target);
+                 containingFn != nullptr && containingFn != &ctx.fn) {
+        // Target lives inside ANOTHER known function (analyzer falsely split a
+        // single PPC function into two). Falling through to emit_function_call
+        // would produce REX_FATAL because no CallEdge exists. Instead, emit an
+        // indirect dispatch via the function table -- the runtime fallback
+        // handler in xmemory.cpp resolves the target by finding the nearest
+        // entry and jumping there, mirroring the build_bl Unknown path.
+        REXCODEGEN_WARN(
+            "Unresolved b target 0x{:08X} from 0x{:08X} lives inside sub_{:08X}: "
+            "emitting indirect dispatch",
+            target, ctx.base, containingFn->base());
+        ctx.println("\tctx.ctr.u32 = 0x{:08X};", target);
+        ctx.println("\tREX_CALL_INDIRECT_FUNC(0x{:08X});", target);
+        ctx.println("\treturn;");
       } else {
         REXCODEGEN_WARN("Unresolved b target 0x{:08X} from 0x{:08X}", target, ctx.base);
         ctx.emit_function_call(target);


### PR DESCRIPTION
Fixes #315

## Summary

`build_b`'s `TargetKind::Unknown` branch falls through to `emit_function_call`, which produces `REX_FATAL` when no `CallEdge` exists for the target. The case where the target lives inside another known function (analyzer falsely split a single PPC function in two — e.g. when PDATA exception data lists an alternate entry mid-function) is currently unhandled.

The companion builder `build_bl`'s `TargetKind::Unknown` branch (control_flow.cpp:96-106) already handles this category by emitting an indirect dispatch via `REX_CALL_INDIRECT_FUNC`. The runtime function-table fallback in `xmemory.cpp` resolves to the nearest entry. This change adds the symmetric path to `build_b`, plus a `return;` (since `b` is unconditional and exits the function, unlike `bl`).

## Change shape

```cpp
} else if (const auto* containingFn = ctx.graph().getFunctionContaining(target);
           containingFn != nullptr && containingFn != &ctx.fn) {
  // ...indirect dispatch + return...
}
```

`FunctionGraph::getFunctionContaining(uint32_t)` is the same API used elsewhere in codegen (`phase_gapfill.cpp:111,258`, `phase_validate.cpp:106,135`).

## Test notes

- `build_bl`'s `Unknown` path uses the same `REX_CALL_INDIRECT_FUNC` mechanism and has been in production. The mirror argument is the strongest claim; per-title verification beyond that is left to reviewers.
- Adding a unit test in `test_recompiler.cpp` covering this case is a sensible follow-up but not part of this PR.

## Why this is right

The asymmetry between `build_b` and `build_bl` for `TargetKind::Unknown` is the core observation. Both target Xenon `b{l}` instructions and the runtime fallback handler accepts both paths.
