### PR TITLE
fix(system): init host FPSCR mask in XHostThread::Execute

### DIFF
--- a/src/system/xthread.cpp
+++ b/src/system/xthread.cpp
@@ -1420,6 +1420,18 @@ void XHostThread::Execute() {
   // Let the kernel know we are starting.
   kernel_state_->OnThreadExecute(this);
 
+  // Match XThread::Execute: initialize the host's FP exception mask so PPC
+  // FP operations dispatched via FunctionDispatcher::Execute don't trap on
+  // inexact/denormal/underflow results that PPC normally masks. Without this,
+  // host threads that re-enter guest code (audio worker, GPU commands, etc.)
+  // crash on STATUS_FLOAT_INEXACT_RESULT (0xC000008F) the first time the
+  // dispatched PPC code does fdivs/etc. Repro: Hexic HD's audio mixer at
+  // sub_9219F7F0+0x3a0 (a divss xmm0, xmm1) faults when called from
+  // AudioSystem::WorkerThreadMain via FunctionDispatcher::Execute.
+  if (auto* ctx = thread_state_->context()) {
+    ctx->fpscr.InitHost();
+  }
+
   int ret = host_fn_();
 
   // Exit.


### PR DESCRIPTION
Fixes #316

## Summary

`XThread::Execute` calls `ctx->fpscr.InitHost()` on entry to mask the host MXCSR's FP exception bits before running guest PPC code. `XHostThread::Execute` (in the same file) does not, even though `host_fn_` commonly dispatches into guest PPC code via `FunctionDispatcher::Execute`. The host MXCSR may have unmasked FP exception bits inherited from earlier non-PPC code (or from libraries that configure SSE differently), and the first FP op in dispatched PPC code traps.

## Concrete repro

Hexic HD's `AudioSystem::WorkerThreadMain` runs on an `XHostThread`. The audio mixer chain reaches `sub_9219F7F0` (a per-frame sample-rate convert routine) whose host-emitted code does `divss xmm0, xmm1`. Without the fix this raises `STATUS_FLOAT_INEXACT_RESULT (0xC000008F)` on the first `divss` call, killing the process ~2s into boot.

## Change shape

Adds 3 lines (within an `if`-guard that confirms the thread state has a context) before `host_fn_()` runs, mirroring the same call already present in `XThread::Execute`:

```cpp
if (auto* ctx = thread_state_->context()) {
  ctx->fpscr.InitHost();
}
```

`InitHost()` is defined in `include/rex/ppc/context.h` and delegates to `FPSCRPlatform::InitHostExceptions(csr)`, which sets the 6 FP mask bits in MXCSR (IM/DM/ZM/OM/UM/PM) — the PPC default state.

## Why this is right

The asymmetry is the core observation: `XThread::Execute` initializes the FP mask, `XHostThread::Execute` does not, but both end up running guest PPC code (host-thread re-entry via `FunctionDispatcher::Execute`). Adding the same call to `XHostThread::Execute` brings the two paths to parity.

## Verification

- The `divss` crash on Hexic HD is reproducible without the change and absent with it.
- Code change is symmetric to existing `XThread::Execute` body — no new mechanism introduced.
- Per-title regression beyond Hexic HD has not been independently exercised; reviewers should evaluate against the symmetry argument.
