### PR TITLE
kernel/xboxkrnl: Add stub return for KeSetPriorityThread

### DIFF
--- a/src/kernel/xboxkrnl/xboxkrnl_threading.cpp
+++ b/src/kernel/xboxkrnl/xboxkrnl_threading.cpp
@@ -1542,7 +1542,7 @@ REX_EXPORT_STUB(__imp__KeSaveFloatingPointState);
 REX_EXPORT_STUB(__imp__KeSaveVectorUnitState);
 REX_EXPORT_STUB(__imp__KeSetBackgroundProcessors);
 REX_EXPORT_STUB(__imp__KeSetPriorityClassThread);
-REX_EXPORT_STUB(__imp__KeSetPriorityThread);
+REX_EXPORT_STUB_RETURN(__imp__KeSetPriorityThread, 0);
 REX_EXPORT_STUB(__imp__KeSetTimer);
 REX_EXPORT_STUB(__imp__KeSetTimerEx);
 REX_EXPORT_STUB(__imp__KeStallExecutionProcessor);


### PR DESCRIPTION
## Summary
Switches the `__imp__KeSetPriorityThread` stub from `REX_EXPORT_STUB` to `REX_EXPORT_STUB_RETURN(..., 0)` so the call returns a stable, valid priority value instead of leaving r3 with whatever was in it before the call.

The change follows the pattern established in 69aec8d (xbdm stub returns).

## Why
`KeSetPriorityThread` returns the previous LONG priority of the thread. With a plain stub the caller reads non-deterministic garbage as the "old priority", which is at best confusing and at worst unsafe if the caller stores it to restore later. Returning 0 (LOW_PRIORITY) is a valid priority value and behaviorally compatible with what the host scheduler is doing anyway (the SDK doesn't honor guest thread priorities).

Observed concretely while bringing up Hexic HD: this stub fires every boot with a STUB warning that has no actionable signal; with the change the call is silent and the return value is well-defined.

## Test plan
- [x] Builds cleanly
- [x] Hexic HD boot path: STUB warning gone, no behavior regression at 60fps