### PR TITLE
fix(cvar): use locale-independent serialization for double cvars

### DIFF
--- a/include/rex/cvar.h
+++ b/include/rex/cvar.h
@@ -235,6 +235,13 @@ inline bool ParseDouble(std::string_view s, double& out) {
   return end != str.c_str() && *end == '\0';
 }
 
+// Locale-independent double → string (TOML requires '.' as decimal separator).
+inline std::string DoubleToString(double v) {
+  char buf[32];
+  auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), v);
+  return ec == std::errc{} ? std::string(buf, ptr) : std::to_string(v);
+}
+
 }  // namespace rex::cvar
 
 //=============================================================================
@@ -363,25 +370,25 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                   std::to_string(default_val),                               \
                                   false})
 
-#define REXCVAR_DEFINE_DOUBLE(name, default_val, category, desc)                 \
-  double FLAGS_##name = (default_val);                                           \
-  static auto _cvar_reg_##name =                                                 \
-      ::rex::cvar::FlagRegistrar({#name,                                         \
-                                  ::rex::cvar::FlagType::Double,                 \
-                                  category,                                      \
-                                  desc,                                          \
-                                  [](std::string_view v) {                       \
-                                    double val = 0;                              \
-                                    if (!::rex::cvar::ParseDouble(v, val))       \
-                                      return false;                              \
-                                    FLAGS_##name = val;                          \
-                                    return true;                                 \
-                                  },                                             \
-                                  []() { return std::to_string(FLAGS_##name); }, \
-                                  []() { return; },                              \
-                                  ::rex::cvar::Lifecycle::kHotReload,            \
-                                  {},                                            \
-                                  std::to_string(default_val),                   \
+#define REXCVAR_DEFINE_DOUBLE(name, default_val, category, desc)                              \
+  double FLAGS_##name = (default_val);                                                        \
+  static auto _cvar_reg_##name =                                                              \
+      ::rex::cvar::FlagRegistrar({#name,                                                      \
+                                  ::rex::cvar::FlagType::Double,                              \
+                                  category,                                                   \
+                                  desc,                                                       \
+                                  [](std::string_view v) {                                    \
+                                    double val = 0;                                           \
+                                    if (!::rex::cvar::ParseDouble(v, val))                    \
+                                      return false;                                           \
+                                    FLAGS_##name = val;                                       \
+                                    return true;                                              \
+                                  },                                                          \
+                                  []() { return ::rex::cvar::DoubleToString(FLAGS_##name); }, \
+                                  []() { return; },                                           \
+                                  ::rex::cvar::Lifecycle::kHotReload,                         \
+                                  {},                                                         \
+                                  ::rex::cvar::DoubleToString(default_val),                   \
                                   false})
 
 #define REXCVAR_DEFINE_STRING(name, default_val, category, desc)                                 \

--- a/src/ui/overlay/settings_overlay.cpp
+++ b/src/ui/overlay/settings_overlay.cpp
@@ -475,7 +475,7 @@ void SettingsDialog::OnDraw(ImGuiIO& /*io*/) {
             v = std::max(v, *entry.constraints.min);
           if (entry.constraints.max)
             v = std::min(v, *entry.constraints.max);
-          rex::cvar::SetFlagByName(entry.name, std::to_string(v));
+          rex::cvar::SetFlagByName(entry.name, rex::cvar::DoubleToString(v));
         }
       } else if (entry.type == rex::cvar::FlagType::Command) {
         if (ImGui::Button(std::string(entry.name + "##v").c_str())) {


### PR DESCRIPTION
std::to_string(double) respects the C locale but can produce comma decimal separators on systems where LC_ALL/LC_NUMERIC is set to a locale like it_IT or de_DE. TOML requires a period, so the written config file would fail to parse on the next launch.

Replace with a std::to_chars-based helper (DoubleToString) which is locale-independent per the C++ standard.

Addresses #318.