### PR TITLE
ssse3: fix building from sources on Linux

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -25,3 +25,7 @@ target_link_libraries(rexaudio
     PUBLIC rexcore SDL3::SDL3
     PRIVATE libavcodec libavutil
 )
+
+if(UNIX)
+    target_compile_options(rexaudio PRIVATE -mssse3)
+endif()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -100,3 +100,6 @@ if(REXGLUE_ENABLE_PERF_COUNTERS)
         $<$<NOT:$<CONFIG:Release>>:REXGLUE_ENABLE_PERF_COUNTERS>)
 endif()
 
+if(UNIX)
+    target_compile_options(rexcore PRIVATE -mssse3)
+endif()

--- a/src/graphics/CMakeLists.txt
+++ b/src/graphics/CMakeLists.txt
@@ -148,3 +148,6 @@ if(REXGLUE_USE_D3D12)
     target_compile_definitions(rexgraphics PUBLIC REX_HAS_D3D12=1)
 endif()
 
+if(UNIX)
+    target_compile_options(rexgraphics PRIVATE -mssse3)
+endif()


### PR DESCRIPTION
This PR changes link in cmakelists fixes this issue: https://github.com/rexglue/rexglue-sdk/issues/321