### PR TITLE
Release v0.7.8

### DIFF
--- a/.github/workflows/_build-platform.yaml
+++ b/.github/workflows/_build-platform.yaml
@@ -61,14 +61,16 @@ jobs:
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev wine vulkan-sdk
+            libgtk-3-dev libx11-xcb-dev wine vulkan-sdk \
+            libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Install build deps (linux-arm64)
         if: inputs.platform == 'linux-arm64'
         run: |
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev libvulkan-dev glslc glslang-tools
+            libgtk-3-dev libx11-xcb-dev libvulkan-dev glslc glslang-tools \
+            libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Set up sccache
         uses: hendrikmuhs/ccache-action@v1.2.22

--- a/include/rex/assert.h
+++ b/include/rex/assert.h
@@ -25,8 +25,12 @@ namespace rex {
 #define static_assert_size(type, size) \
   static_assert(sizeof(type) == size, "bad definition for " #type ": must be " #size " bytes")
 
-// We rely on assert being compiled out in NDEBUG.
-#define rex_assert assert
+#ifdef NDEBUG
+// References expr in an unevaluated short-circuit so -Wunused doesn't fire.
+#define rex_assert(expr) ((void)(false && (expr)))
+#else
+#define rex_assert(expr) assert(expr)
+#endif
 
 #define __REX_EXPAND(x) x
 #define __REX_ARGC(...) \

--- a/include/rex/codegen/code_emitter.h
+++ b/include/rex/codegen/code_emitter.h
@@ -19,7 +19,7 @@
 namespace rex::codegen {
 
 // Forward declarations
-class RecompilerConfig;
+struct RecompilerConfig;
 
 /**
  * @brief CSR (Control/Status Register) state for FPU denormal handling.

--- a/include/rex/cvar.h
+++ b/include/rex/cvar.h
@@ -294,8 +294,8 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                   std::to_string(default_val),                               \
                                   false})
 
-#define REXCVAR_DEFINE_INT64(name, default_val, category, desc) \
-  int64_t FLAGS_##name = (default_val);                         \
+#define REXCVAR_DEFINE_INT64(name, default_val, category, desc)                              \
+  int64_t FLAGS_##name = (default_val);                                                      \
   static auto _cvar_reg_##name =                                                             \
       ::rex::cvar::FlagRegistrar({#name,                                                     \
                                   ::rex::cvar::FlagType::Int64,                              \
@@ -311,7 +311,7 @@ inline bool ParseDouble(std::string_view s, double& out) {
                                     return true;                                             \
                                   },                                                         \
                                   []() { return std::to_string(FLAGS_##name); },             \
-                                  []() { return; },                                          \ 
+                                  []() { return; },                                          \
                                   ::rex::cvar::Lifecycle::kHotReload,                        \
                                   {},                                                        \
                                   std::to_string(default_val),                               \

--- a/include/rex/filesystem/devices/stfs_container_file.h
+++ b/include/rex/filesystem/devices/stfs_container_file.h
@@ -27,11 +27,11 @@ class StfsContainerFile : public File {
   void Destroy() override;
 
   X_STATUS ReadSync(std::span<uint8_t> buffer, size_t byte_offset, size_t* out_bytes_read) override;
-  X_STATUS WriteSync(std::span<const uint8_t> buffer, size_t byte_offset,
-                     size_t* out_bytes_written) override {
+  X_STATUS WriteSync(std::span<const uint8_t> /*buffer*/, size_t /*byte_offset*/,
+                     size_t* /*out_bytes_written*/) override {
     return X_STATUS_ACCESS_DENIED;
   }
-  X_STATUS SetLength(size_t length) override { return X_STATUS_ACCESS_DENIED; }
+  X_STATUS SetLength(size_t /*length*/) override { return X_STATUS_ACCESS_DENIED; }
 
  private:
   StfsContainerEntry* entry_;

--- a/include/rex/filesystem/devices/stfs_xbox.h
+++ b/include/rex/filesystem/devices/stfs_xbox.h
@@ -29,7 +29,7 @@ using rex::system::XLanguage;
 
 // Convert FAT timestamp to 100-nanosecond intervals since January 1, 1601 (UTC)
 inline uint64_t decode_fat_timestamp(const uint32_t date, const uint32_t time) {
-  struct tm tm = {0};
+  struct tm tm = {};
   // 80 is the difference between 1980 (FAT) and 1900 (tm);
   tm.tm_year = ((0xFE00 & date) >> 9) + 80;
   tm.tm_mon = ((0x01E0 & date) >> 5) - 1;

--- a/include/rex/graphics/format/ucode.h
+++ b/include/rex/graphics/format/ucode.h
@@ -235,10 +235,10 @@ struct ControlFlowExecInstruction {
   uint32_t count_ : 3;
   uint32_t is_yield_ : 1;
   uint32_t sequence_ : 12;
-  uint32_t vc_hi_ : 4;  // Vertex cache?
+  [[maybe_unused]] uint32_t vc_hi_ : 4;  // Vertex cache?
 
   // Word 1: (16 bits)
-  uint32_t vc_lo_ : 2;
+  [[maybe_unused]] uint32_t vc_lo_ : 2;
   uint32_t : 7;
   // According to the description of Conditional_Execute_Predicates_No_Stall in
   // the IPR2015-00325 sequencer specification, the sequencer's control flow
@@ -280,10 +280,10 @@ struct ControlFlowCondExecInstruction {
   uint32_t count_ : 3;
   uint32_t is_yield_ : 1;
   uint32_t sequence_ : 12;
-  uint32_t vc_hi_ : 4;  // Vertex cache?
+  [[maybe_unused]] uint32_t vc_hi_ : 4;  // Vertex cache?
 
   // Word 1: (16 bits)
-  uint32_t vc_lo_ : 2;
+  [[maybe_unused]] uint32_t vc_lo_ : 2;
   uint32_t bool_address_ : 8;
   uint32_t condition_ : 1;
   AddressingMode address_mode_ : 1;
@@ -314,10 +314,10 @@ struct ControlFlowCondExecPredInstruction {
   uint32_t count_ : 3;
   uint32_t is_yield_ : 1;
   uint32_t sequence_ : 12;
-  uint32_t vc_hi_ : 4;  // Vertex cache?
+  [[maybe_unused]] uint32_t vc_hi_ : 4;  // Vertex cache?
 
   // Word 1: (16 bits)
-  uint32_t vc_lo_ : 2;
+  [[maybe_unused]] uint32_t vc_lo_ : 2;
   uint32_t : 7;
   uint32_t is_predicate_clean_ : 1;
   uint32_t condition_ : 1;
@@ -457,7 +457,7 @@ struct ControlFlowCondJmpInstruction {
 
   // Word 1: (16 bits)
   uint32_t : 1;
-  uint32_t direction_ : 1;
+  [[maybe_unused]] uint32_t direction_ : 1;
   uint32_t bool_address_ : 8;
   uint32_t condition_ : 1;
   AddressingMode address_mode_ : 1;
@@ -480,7 +480,7 @@ struct ControlFlowAllocInstruction {
 
   // Word 1: (16 bits)
   uint32_t : 8;
-  uint32_t is_unserialized_ : 1;
+  uint32_t : 1;  // is_unserialized_
   AllocType alloc_type_ : 2;
   uint32_t : 1;
   ControlFlowOpcode opcode_ : 4;

--- a/include/rex/graphics/graphics_system.h
+++ b/include/rex/graphics/graphics_system.h
@@ -62,7 +62,7 @@ class GraphicsSystem : public system::IGraphicsSystem {
   X_STATUS SetupGuestGpu(runtime::FunctionDispatcher* function_dispatcher,
                          system::KernelState* kernel_state) override;
   bool has_presentation() const override { return presenter_ != nullptr; }
-  virtual void Shutdown();
+  void Shutdown() override;
 
   // May be called from any thread any number of times, even during recovery
   // from a device loss.

--- a/include/rex/graphics/pipeline/shader/dxbc.h
+++ b/include/rex/graphics/pipeline/shader/dxbc.h
@@ -50,7 +50,7 @@ class DxbcShader : public Shader {
   const std::vector<TextureBinding>& GetTextureBindingsAfterTranslation() const {
     return texture_bindings_;
   }
-  const uint32_t GetUsedTextureMaskAfterTranslation() const { return used_texture_mask_; }
+  uint32_t GetUsedTextureMaskAfterTranslation() const { return used_texture_mask_; }
 
   static constexpr uint32_t kMaxSamplerBindingIndexBits =
       DxbcShaderTranslator::kMaxSamplerBindingIndexBits;

--- a/include/rex/graphics/pipeline/shader/interpreter.h
+++ b/include/rex/graphics/pipeline/shader/interpreter.h
@@ -33,9 +33,9 @@ class ShaderInterpreter {
   class ExportSink {
    public:
     virtual ~ExportSink() = default;
-    virtual void AllocExport(ucode::AllocType type, uint32_t size) {}
-    virtual void Export(ucode::ExportRegister export_register, const float* value,
-                        uint32_t value_mask) {}
+    virtual void AllocExport(ucode::AllocType /*type*/, uint32_t /*size*/) {}
+    virtual void Export(ucode::ExportRegister /*export_register*/, const float* /*value*/,
+                        uint32_t /*value_mask*/) {}
   };
 
   void SetTraceWriter(TraceWriter* new_trace_writer) { trace_writer_ = new_trace_writer; }

--- a/include/rex/graphics/pipeline/shader/shader.h
+++ b/include/rex/graphics/pipeline/shader/shader.h
@@ -1005,7 +1005,7 @@ class Shader {
   std::string ucode_disassembly_;
   std::vector<VertexBinding> vertex_bindings_;
   std::vector<TextureBinding> texture_bindings_;
-  ConstantRegisterMap constant_register_map_ = {0};
+  ConstantRegisterMap constant_register_map_ = {};
   std::set<uint32_t> label_addresses_;
   uint32_t cf_pair_index_bound_ = 0;
   uint32_t register_static_address_bound_ = 0;

--- a/include/rex/graphics/pipeline/shader/translator.h
+++ b/include/rex/graphics/pipeline/shader/translator.h
@@ -29,13 +29,13 @@ class ShaderTranslator {
   virtual ~ShaderTranslator();
 
   virtual uint64_t GetDefaultVertexShaderModification(
-      uint32_t dynamic_addressable_register_count,
-      Shader::HostVertexShaderType host_vertex_shader_type =
+      uint32_t /*dynamic_addressable_register_count*/,
+      Shader::HostVertexShaderType /*host_vertex_shader_type*/ =
           Shader::HostVertexShaderType::kVertex) const {
     return 0;
   }
   virtual uint64_t GetDefaultPixelShaderModification(
-      uint32_t dynamic_addressable_register_count) const {
+      uint32_t /*dynamic_addressable_register_count*/) const {
     return 0;
   }
 
@@ -84,51 +84,52 @@ class ShaderTranslator {
 
   // Pre-process a control-flow instruction before anything else.
   virtual void PreProcessControlFlowInstructions(
-      std::vector<ucode::ControlFlowInstruction> instrs) {}
+      std::vector<ucode::ControlFlowInstruction> /*instrs*/) {}
 
   // Handles translation for control flow label addresses.
   // This is triggered once for each label required (due to control flow
   // operations) before any of the instructions within the target exec.
-  virtual void ProcessLabel(uint32_t cf_index) {}
+  virtual void ProcessLabel(uint32_t /*cf_index*/) {}
 
   // Handles translation for control flow nop instructions.
-  virtual void ProcessControlFlowNopInstruction(uint32_t cf_index) {}
+  virtual void ProcessControlFlowNopInstruction(uint32_t /*cf_index*/) {}
   // Handles the start of a control flow instruction at the given address.
-  virtual void ProcessControlFlowInstructionBegin(uint32_t cf_index) {}
+  virtual void ProcessControlFlowInstructionBegin(uint32_t /*cf_index*/) {}
   // Handles the end of a control flow instruction that began at the given
   // address.
-  virtual void ProcessControlFlowInstructionEnd(uint32_t cf_index) {}
+  virtual void ProcessControlFlowInstructionEnd(uint32_t /*cf_index*/) {}
   // Handles translation for control flow exec instructions prior to their
   // contained ALU/fetch instructions.
-  virtual void ProcessExecInstructionBegin(const ParsedExecInstruction& instr) {}
+  virtual void ProcessExecInstructionBegin(const ParsedExecInstruction& /*instr*/) {}
   // Handles translation for control flow exec instructions after their
   // contained ALU/fetch instructions.
-  virtual void ProcessExecInstructionEnd(const ParsedExecInstruction& instr) {}
+  virtual void ProcessExecInstructionEnd(const ParsedExecInstruction& /*instr*/) {}
   // Handles translation for loop start instructions.
-  virtual void ProcessLoopStartInstruction(const ParsedLoopStartInstruction& instr) {}
+  virtual void ProcessLoopStartInstruction(const ParsedLoopStartInstruction& /*instr*/) {}
   // Handles translation for loop end instructions.
-  virtual void ProcessLoopEndInstruction(const ParsedLoopEndInstruction& instr) {}
+  virtual void ProcessLoopEndInstruction(const ParsedLoopEndInstruction& /*instr*/) {}
   // Handles translation for function call instructions.
-  virtual void ProcessCallInstruction(const ParsedCallInstruction& instr) {}
+  virtual void ProcessCallInstruction(const ParsedCallInstruction& /*instr*/) {}
   // Handles translation for function return instructions.
-  virtual void ProcessReturnInstruction(const ParsedReturnInstruction& instr) {}
+  virtual void ProcessReturnInstruction(const ParsedReturnInstruction& /*instr*/) {}
   // Handles translation for jump instructions.
-  virtual void ProcessJumpInstruction(const ParsedJumpInstruction& instr) {}
+  virtual void ProcessJumpInstruction(const ParsedJumpInstruction& /*instr*/) {}
   // Handles translation for alloc instructions. Memory exports for eM#
   // indicated by export_eM must be performed, regardless of the alloc type.
-  virtual void ProcessAllocInstruction(const ParsedAllocInstruction& instr, uint8_t export_eM) {}
+  virtual void ProcessAllocInstruction(const ParsedAllocInstruction& /*instr*/,
+                                       uint8_t /*export_eM*/) {}
 
   // Handles translation for vertex fetch instructions.
-  virtual void ProcessVertexFetchInstruction(const ParsedVertexFetchInstruction& instr) {}
+  virtual void ProcessVertexFetchInstruction(const ParsedVertexFetchInstruction& /*instr*/) {}
   // Handles translation for texture fetch instructions.
-  virtual void ProcessTextureFetchInstruction(const ParsedTextureFetchInstruction& instr) {}
+  virtual void ProcessTextureFetchInstruction(const ParsedTextureFetchInstruction& /*instr*/) {}
   // Handles translation for ALU instructions.
   // memexport_eM_potentially_written_before needs to be handled by `kill`
   // instruction to make sure memory exports for the eM# writes earlier in
   // previous execs and the current exec are done before the invocation becomes
   // inactive.
-  virtual void ProcessAluInstruction(const ParsedAluInstruction& instr,
-                                     uint8_t memexport_eM_potentially_written_before) {}
+  virtual void ProcessAluInstruction(const ParsedAluInstruction& /*instr*/,
+                                     uint8_t /*memexport_eM_potentially_written_before*/) {}
 
  private:
   void TranslateControlFlowInstruction(const ucode::ControlFlowInstruction& cf);

--- a/include/rex/graphics/pipeline/texture/cache.h
+++ b/include/rex/graphics/pipeline/texture/cache.h
@@ -83,8 +83,9 @@ class TextureCache {
   void MarkRangeAsResolved(uint32_t start_unscaled, uint32_t length_unscaled);
   // Ensures the memory backing the range in the scaled resolve address space is
   // allocated and returns whether it is.
-  virtual bool EnsureScaledResolveMemoryCommitted(uint32_t start_unscaled, uint32_t length_unscaled,
-                                                  uint32_t length_scaled_alignment_log2 = 0) {
+  virtual bool EnsureScaledResolveMemoryCommitted(uint32_t /*start_unscaled*/,
+                                                  uint32_t /*length_unscaled*/,
+                                                  uint32_t /*length_scaled_alignment_log2*/ = 0) {
     return false;
   }
 
@@ -484,11 +485,11 @@ class TextureCache {
   // Whether the signed version of the texture has a different representation on
   // the host than its unsigned version (for example, if it's a fixed-point
   // texture emulated with a larger host pixel format).
-  virtual bool IsSignedVersionSeparateForFormat(TextureKey key) const { return false; }
+  virtual bool IsSignedVersionSeparateForFormat(TextureKey /*key*/) const { return false; }
   // Parameters like whether the texture is tiled and its dimensions are checked
   // externally, the implementation should take only format-related parameters
   // such as the format itself and the signedness into account.
-  virtual bool IsScaledResolveSupportedForFormat(TextureKey key) const { return false; }
+  virtual bool IsScaledResolveSupportedForFormat(TextureKey /*key*/) const { return false; }
   // For formats with less than 4 components, implementations normally should
   // replicate the last component into the non-existent ones, similar to what is
   // done for unused components of operands in shaders by Microsoft's Xbox 360
@@ -542,7 +543,7 @@ class TextureCache {
   }
   // Called when something in a texture binding is changed for the
   // implementation to update the internal dependencies of the binding.
-  virtual void UpdateTextureBindingsImpl(uint32_t fetch_constant_mask) {}
+  virtual void UpdateTextureBindingsImpl(uint32_t /*fetch_constant_mask*/) {}
 
  private:
   struct PendingTextureLoad {

--- a/src/audio/nop/nop_audio_system.cpp
+++ b/src/audio/nop/nop_audio_system.cpp
@@ -24,8 +24,8 @@ NopAudioSystem::NopAudioSystem(runtime::FunctionDispatcher* function_dispatcher)
 
 NopAudioSystem::~NopAudioSystem() = default;
 
-X_STATUS NopAudioSystem::CreateDriver(size_t index, rex::thread::Semaphore* semaphore,
-                                      AudioDriver** out_driver) {
+X_STATUS NopAudioSystem::CreateDriver(size_t /*index*/, rex::thread::Semaphore* /*semaphore*/,
+                                      AudioDriver** /*out_driver*/) {
   return X_STATUS_NOT_IMPLEMENTED;
 }
 

--- a/src/codegen/ppc/disasm.cpp
+++ b/src/codegen/ppc/disasm.cpp
@@ -13,13 +13,23 @@
 
 namespace rex::codegen::ppc {
 
-thread_local DisassemblerEngine gBigEndianDisassembler{BFD_ENDIAN_BIG, "cell 64"};
+// Binutils PPC_OPCODE_* dialect bits (see thirdparty/disasm/ppc-dis.c)
+constexpr uintptr_t kXenonDialect = 0x1          // PPC
+                                    | 0x4        // 64
+                                    | 0x4000     // POWER4
+                                    | 0x8000000  // CELL
+                                    | 0x200      // ALTIVEC
+                                    | 0x1000000  // VMX_128
+                                    | 0x10000;   // CLASSIC
+
+thread_local DisassemblerEngine gBigEndianDisassembler{BFD_ENDIAN_BIG, nullptr};
 
 DisassemblerEngine::DisassemblerEngine(bfd_endian endian, const char* options) {
   INIT_DISASSEMBLE_INFO(info, stdout, fprintf);
   info.arch = bfd_arch_powerpc;
   info.endian = endian;
   info.disassembler_options = options;
+  info.private_data = reinterpret_cast<void*>(kXenonDialect);
 }
 
 int DisassemblerEngine::Disassemble(const void* code, size_t size, uint64_t base, ppc_insn& out) {

--- a/src/core/arena.cpp
+++ b/src/core/arena.cpp
@@ -114,6 +114,7 @@ void* Arena::CloneContents() {
 }
 
 void Arena::CloneContents(void* buffer, size_t buffer_length) {
+  assert_true(buffer_length >= CalculateSize(), "destination buffer is too small");
   uint8_t* p = reinterpret_cast<uint8_t*>(buffer);
   Chunk* chunk = head_chunk_;
   while (chunk) {

--- a/src/core/filesystem_win.cpp
+++ b/src/core/filesystem_win.cpp
@@ -208,7 +208,7 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(const std::filesystem::path
 
 bool GetInfo(const std::filesystem::path& path, FileInfo* out_info) {
   *out_info = FileInfo{};
-  WIN32_FILE_ATTRIBUTE_DATA data = {0};
+  WIN32_FILE_ATTRIBUTE_DATA data = {};
   if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &data)) {
     return false;
   }

--- a/src/filesystem/devices/disc_image_device.cpp
+++ b/src/filesystem/devices/disc_image_device.cpp
@@ -36,7 +36,7 @@ bool DiscImageDevice::Initialize() {
     return false;
   }
 
-  ParseState state = {0, 0};
+  ParseState state = {};
   state.ptr = mmap_->data();
   state.size = mmap_->size();
   auto result = Verify(&state);

--- a/src/graphics/CMakeLists.txt
+++ b/src/graphics/CMakeLists.txt
@@ -115,6 +115,8 @@ target_include_directories(rexgraphics PRIVATE
     ${REXGLUE_ROOT}  # For thirdparty/dxbc/DXBCChecksum.h include
 )
 
+target_compile_options(rexgraphics PRIVATE -Wno-unused-variable)
+
 target_link_libraries(rexgraphics PUBLIC
     rexcore
     rexsystem

--- a/src/kernel/crt/file.cpp
+++ b/src/kernel/crt/file.cpp
@@ -326,8 +326,24 @@ u32 CreateDirectoryA_entry(mapped_string lpPathName, mapped_void lpSecurityAttri
 }
 
 u32 MoveFileA_entry(mapped_string lpExistingFileName, mapped_string lpNewFileName) {
-  REXKRNL_WARN("rexcrt_MoveFileA: STUB '{}' -> '{}'", static_cast<const char*>(lpExistingFileName),
-               static_cast<const char*>(lpNewFileName));
+  const char* src = static_cast<const char*>(lpExistingFileName);
+  const char* dst = static_cast<const char*>(lpNewFileName);
+
+  auto* fs = REX_KERNEL_FS();
+  auto* src_entry = fs->ResolvePath(src);
+  if (!src_entry) {
+    REXKRNL_DEBUG("rexcrt_MoveFileA: source not found '{}'", src);
+    return 0;
+  }
+  // Win32 MoveFileA fails if the destination already exists; callers wanting
+  // overwrite semantics use MoveFileExA with MOVEFILE_REPLACE_EXISTING.
+  if (fs->ResolvePath(dst)) {
+    REXKRNL_DEBUG("rexcrt_MoveFileA: destination exists '{}'", dst);
+    return 0;
+  }
+
+  src_entry->Rename(rex::to_path(dst));
+  REXKRNL_TRACE("rexcrt_MoveFileA: '{}' -> '{}'", src, dst);
   return 1;
 }
 

--- a/src/kernel/xam/xam_net.cpp
+++ b/src/kernel/xam/xam_net.cpp
@@ -176,7 +176,7 @@ struct XNetStartupParams {
   uint8_t cfgQosPairWaitTimeInSeconds;
 };
 
-XNetStartupParams xnet_startup_params = {0};
+XNetStartupParams xnet_startup_params = {};
 
 u32 NetDll_XNetStartup_entry(u32 caller, ppc_ptr_t<XNetStartupParams> params) {
   if (params) {
@@ -794,20 +794,20 @@ struct host_set {
 i32 NetDll_select_entry(i32 caller, i32 nfds, ppc_ptr_t<x_fd_set> readfds,
                         ppc_ptr_t<x_fd_set> writefds, ppc_ptr_t<x_fd_set> exceptfds,
                         mapped_void timeout_ptr) {
-  host_set host_readfds = {0};
-  fd_set native_readfds = {0};
+  host_set host_readfds = {};
+  fd_set native_readfds = {};
   if (readfds) {
     host_readfds.Load(readfds);
     host_readfds.Store(&native_readfds);
   }
-  host_set host_writefds = {0};
-  fd_set native_writefds = {0};
+  host_set host_writefds = {};
+  fd_set native_writefds = {};
   if (writefds) {
     host_writefds.Load(writefds);
     host_writefds.Store(&native_writefds);
   }
-  host_set host_exceptfds = {0};
-  fd_set native_exceptfds = {0};
+  host_set host_exceptfds = {};
+  fd_set native_exceptfds = {};
   if (exceptfds) {
     host_exceptfds.Load(exceptfds);
     host_exceptfds.Store(&native_exceptfds);

--- a/src/kernel/xboxkrnl/xboxkrnl_threading.cpp
+++ b/src/kernel/xboxkrnl/xboxkrnl_threading.cpp
@@ -1346,7 +1346,7 @@ u32 InterlockedPushEntrySList_entry(ppc_ptr_t<X_SLIST_HEADER> plist_ptr,
   assert_not_null(entry);
 
   alignas(8) X_SLIST_HEADER old_hdr = *plist_ptr;
-  alignas(8) X_SLIST_HEADER new_hdr = {0};
+  alignas(8) X_SLIST_HEADER new_hdr = {};
   uint32_t old_head = 0;
   do {
     old_hdr = *plist_ptr;

--- a/src/rexglue/commands/test_recompiler.cpp
+++ b/src/rexglue/commands/test_recompiler.cpp
@@ -324,34 +324,6 @@ std::vector<TestSpec> parse_test_specs(
 
   return specs;
 }
-
-/// Extract symbols from disassembly file
-std::unordered_map<std::string, std::string> parse_disassembly(
-    const std::string& disPath, const std::string& stem,
-    const std::unordered_set<size_t>& validAddresses) {
-  std::unordered_map<std::string, std::string> symbols;
-  std::ifstream in(disPath);
-  if (!in.is_open()) {
-    return symbols;
-  }
-
-  std::string line;
-  while (std::getline(in, line)) {
-    auto spaceIndex = line.find(' ');
-    auto bracketIndex = line.find('>');
-    if (spaceIndex != std::string::npos && bracketIndex != std::string::npos) {
-      size_t address = ~0ull;
-      std::from_chars(&line[0], &line[spaceIndex], address, 16);
-      address &= 0xFFFFF;  // Mask to test addresses
-      if (validAddresses.find(address) != validAddresses.end()) {
-        auto name = line.substr(spaceIndex + 2, bracketIndex - spaceIndex - 2);
-        symbols.emplace(name, fmt::format("{}_{:X}", stem, address));
-      }
-    }
-  }
-  return symbols;
-}
-
 }  // anonymous namespace
 
 bool recompile_tests(const std::string_view& binDirPath, const std::string_view& asmDirPath,

--- a/src/system/util/xdbf_utils.cpp
+++ b/src/system/util/xdbf_utils.cpp
@@ -59,7 +59,7 @@ XdbfBlock XdbfWrapper::GetEntry(XdbfSection section, uint64_t id) const {
       return block;
     }
   }
-  return {0};
+  return {};
 }
 
 std::string XdbfWrapper::GetStringTableEntry(XLanguage language, uint16_t string_id) const {

--- a/src/ui/window_win.cpp
+++ b/src/ui/window_win.cpp
@@ -1251,7 +1251,7 @@ LRESULT Win32Window::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPar
           TABLET_DISABLE_TOUCHUIFORCEON | TABLET_ENABLE_MULTITOUCHDATA;
 
     case WM_MENUCOMMAND: {
-      MENUINFO menu_info = {0};
+      MENUINFO menu_info = {};
       menu_info.cbSize = sizeof(menu_info);
       menu_info.fMask = MIM_MENUDATA;
       GetMenuInfo(HMENU(lParam), &menu_info);
@@ -1339,7 +1339,7 @@ Win32MenuItem::Win32MenuItem(Type type, const std::string& text, const std::stri
       break;
   }
   if (handle_) {
-    MENUINFO menu_info = {0};
+    MENUINFO menu_info = {};
     menu_info.cbSize = sizeof(menu_info);
     menu_info.fMask = MIM_MENUDATA | MIM_STYLE;
     menu_info.dwMenuData = ULONG_PTR(this);

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -260,6 +260,16 @@ set(SDL_DISKAUDIO OFF CACHE BOOL "" FORCE)
 set(SDL_DUMMYAUDIO OFF CACHE BOOL "" FORCE)
 set(SDL_DUMMYVIDEO OFF CACHE BOOL "" FORCE)
 
+# Linux audio backends
+if(UNIX AND NOT APPLE)
+    set(SDL_ALSA              ON  CACHE BOOL "" FORCE)
+    set(SDL_ALSA_SHARED       ON  CACHE BOOL "" FORCE)
+    set(SDL_PULSEAUDIO        ON  CACHE BOOL "" FORCE)
+    set(SDL_PULSEAUDIO_SHARED ON  CACHE BOOL "" FORCE)
+    set(SDL_PIPEWIRE          ON  CACHE BOOL "" FORCE)
+    set(SDL_PIPEWIRE_SHARED   ON  CACHE BOOL "" FORCE)
+endif()
+
 add_subdirectory(sdl3)
 
 #=============================================================================

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(renderdoc INTERFACE
 
 # tomlplusplus - TOML config file parser (header-only)
 add_library(tomlplusplus INTERFACE)
-target_include_directories(tomlplusplus INTERFACE
+target_include_directories(tomlplusplus SYSTEM INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tomlplusplus/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 


### PR DESCRIPTION
## Summary

- Override binutils dialect so `vmx128` instructions decode over `ppc405` ops (fixes `vsldoi128` being decoded as `mullhwu.`, etc)
- Correct forward declaration type for `RecompilerConfig`
- Implement `MoveFileA` in rexcrt
- Require Linux audio backends rather than silently falling back (fixes no-audio in Linux CI/CD builds, Thank you @birabittoh!)
- Mark `tomlplusplus` includes as `SYSTEM` to silence header warnings
- Suppress unused variable warnings in graphics lib
- Value initialize objects to silence `-Wmissing-field-initializers`
- Drop ineffective `const` on by-value return types
- Comment out unused params in empty virtual defaults
- Mark `GraphicsSystem::Shutdown` `override`
- Use short-circuit `&&` for `-Wunused` suppression in assert macro
- Assert buffer is large enough in `Arena::CloneContents`
- Mark unused ucode bit-fields with `[[maybe_unused]]`
- `include/rex/cvar.h` file cleanup and formatting