### PR TITLE
Emit type / enum headers from config-supplied data

### DIFF
--- a/docs/types_and_enums.md
+++ b/docs/types_and_enums.md
@@ -1,0 +1,256 @@
+# Type / enum header emission
+
+Optional codegen step that materialises producer-supplied
+`[[types]]` / `[[enums]]` config arrays into two header files
+alongside the recompiler's `.cpp` output:
+
+```
+<out_directory_path>/mappings_generated/types.h
+<out_directory_path>/mappings_generated/enums.h
+```
+
+The headers are pure declarations — they pull in `<cstddef>` /
+`<cstdint>` and nothing else. Each producer type becomes an opaque
+`struct` of the right size, guarded by `static_assert(sizeof(...) ==
+size)`, with a sibling `<Type>_offsets` namespace whose members are
+`inline constexpr size_t` field offsets. Each producer enum becomes
+a strongly-typed `enum class` with a fixed-width underlying type.
+
+## When to use this
+
+A mapping file is the right tool when the host substrate (audio /
+graphics / kernel HAL code) has to address PPC-side data with
+hand-coded byte offsets:
+
+```cpp
+// kernel shim: clear the alerted byte on a thread
+*((uint8_t*)thread + 0x6D) = 0;
+```
+
+With type headers emitted from the same producer the recompiler
+already trusts for function names, the same shim becomes:
+
+```cpp
+*((uint8_t*)thread + _KTHREAD_offsets::Alerted) = 0;
+```
+
+Self-documenting, drift-detectable (the constant fails the build if
+the producer ever changes), zero-overhead at runtime.
+
+This feature is *not* required for codegen and is a no-op unless the
+config supplies `[[types]]` and/or `[[enums]]` arrays.
+
+## Schema
+
+`[[types]]` and `[[enums]]` are top-level arrays-of-tables, parsed
+from any included config file with the same merge semantics as
+`[[switch_tables]]` and `[[invalid_instructions]]`. Place them in
+the project's main config or in a separate file pulled in via
+`includes`.
+
+### `[[types]]`
+
+| Field | Type | Required | Use |
+|-------|------|----------|-----|
+| `name` | string | yes | Display name (`_KTHREAD`, `Vehicle::State`). Sanitized into a C++ identifier. Anonymous tags (`<unnamed-tag>`) are skipped. |
+| `size` | uint32 | yes (effectively) | sizeof, in bytes. `0` skips the static_assert and uses `_opaque[0x1]`. |
+| `kind` | string | no | `"struct"` / `"union"` / `"class"`. Header comment only; emitted as `struct` regardless (opaque storage). Defaults to `"struct"`. |
+| `unique_name` | string | no | Producer's mangled / unique name. Header comment only. |
+| `[[types.fields]]` | array | no | Per-field offset entries. |
+
+Per `[[types.fields]]` entry:
+
+| Field | Type | Required | Use |
+|-------|------|----------|-----|
+| `name` | string | yes | Sanitized to a C++ identifier; reserved-word names (`register`, `not`, ...) are prefixed with `f_`. |
+| `offset` | uint32 | yes | Bytes from the start of the parent type. |
+| `type_expr` | string | no | Raw producer type expression. Preserved verbatim and emitted as a comment beside the offset constant. *Not parsed* — translating producer type expressions into self-consistent C++ is intentionally out of scope. |
+
+### `[[enums]]`
+
+| Field | Type | Required | Use |
+|-------|------|----------|-----|
+| `name` | string | yes | Display name. Sanitized; anonymous tags skipped. |
+| `underlying` | string | no | Producer's integer type (`int`, `unsigned long`, `char`, `unsigned char`). Defaults to `int`. Translated to a fixed-width type at emit time (see "Underlying-type mapping"). |
+| `unique_name` | string | no | Header comment only. |
+| `[[enums.values]]` | array | yes (non-empty for non-empty enums) | Per-enumerator entries. |
+
+Per `[[enums.values]]` entry:
+
+| Field | Type | Required | Use |
+|-------|------|----------|-----|
+| `name` | string | yes | Sanitized to a C++ identifier. |
+| `value` | int64 | yes | Signed-widened — fits both signed and unsigned underlyings. Narrowing happens at the `enum class` boundary. |
+
+## Sanitization
+
+Type / enum / nested-name sanitizer (separate from the function-name
+sanitizer):
+
+1. Anonymous producer names (anything starting with `<`, e.g.
+   `<unnamed-tag>`) are skipped — they cannot be surfaced at file
+   scope without a synthesized stable identifier, and the producer
+   doesn't give us one.
+2. `::` collapses to `__` (preserves the scope marker).
+3. Each remaining non-`[A-Za-z0-9_]` byte becomes `_`.
+4. Empty / leading-digit results are dropped (counts as
+   "anonymous or unsanitizable").
+
+There is intentionally **no address suffix** — types and enums are
+name-keyed, not address-keyed. When two distinct producer entries
+sanitize to the same identifier, the first wins; subsequent
+collisions are dropped silently (logged at `[debug]`).
+
+Field names use a stricter sanitizer (no `::` handling) plus a C++
+keyword guard: a sanitized field name that collides with a reserved
+word gets an `f_` prefix. Enum value names skip the guard because
+producer enumerators are conventionally upper-case and collisions
+don't arise in practice.
+
+## Layout rules
+
+### Types
+
+```cpp
+// <raw_name> (kind=<kind>, unique_name=<unique>)
+struct <sanitized_name> {
+    unsigned char _opaque[0x<size>];
+};
+static_assert(sizeof(<sanitized_name>) == 0x<size>, "<name> size mismatch with producer");
+namespace <sanitized_name>_offsets {
+    inline constexpr size_t <FieldA> = 0x<off>; // <raw_field_type>
+    // ...
+}
+```
+
+The opaque-buffer choice is what makes this a tractable feature
+rather than a multi-month type-system project. Consumers that need
+named-field access cast through the offset constants:
+
+```cpp
+auto* tlsData = *(void**)((uint8_t*)thread + _KTHREAD_offsets::TlsData);
+```
+
+`size == 0` skips the `static_assert` and the buffer becomes
+`unsigned char _opaque[0x1]` (`sizeof(struct)` is always >= 1, so a
+zero static_assert would always fail). Affects forward-declared
+types where the producer doesn't carry a definition.
+
+Anonymous unions and bitfields are flattened in the offsets
+namespace: multiple fields at the same `offset` produce one entry
+per unique sanitized name (first occurrence wins). The header is
+documenting layout, not reproducing union semantics.
+
+### Enums
+
+```cpp
+// <raw_name> (underlying=<u>, unique_name=<unique>)
+enum class <sanitized_name> : <fixed_width_underlying> {
+    VALUE_A = 0,
+    VALUE_B = 1,
+};
+```
+
+Underlying-type mapping:
+
+| Producer string | C++ underlying |
+|----------------|----------------|
+| `char` | `int8_t` |
+| `unsigned char` | `uint8_t` |
+| `short` | `int16_t` |
+| `unsigned short` | `uint16_t` |
+| `int` | `int32_t` |
+| `unsigned int` | `uint32_t` |
+| `long` | `int32_t` |
+| `unsigned long` | `uint32_t` |
+| `__int64` | `int64_t` |
+| `unsigned __int64` | `uint64_t` |
+| `bool` | `bool` |
+| anything else | `int32_t` (MSVC default) |
+
+The Xbox 360 ABI maps `long` to 32 bits, matching MSVC PPC.
+
+`enum class` is preferred over plain `enum` so values must be
+qualified at use sites (`VehicleClass::Sedan`); this dodges the
+collision class where two producer enums share value names.
+
+Values within a single enum dedupe on sanitized name (first wins)
+because two enumerators with the same name would be a hard C++
+error.
+
+## Example
+
+```toml
+# project.toml
+project_name = "myproject"
+file_path = "default.xex"
+out_directory_path = "generated"
+
+includes = ["pdb_types.toml"]
+
+# pdb_types.toml
+[[types]]
+name        = "Vehicle"
+unique_name = ".?AVVehicle@@"
+kind        = "class"
+size        = 0x80
+
+[[types.fields]]
+name      = "rpm"
+type_expr = "float"
+offset    = 0x10
+
+[[types.fields]]
+name      = "wheels"
+type_expr = "Wheel[4]"
+offset    = 0x20
+
+[[enums]]
+name        = "VehicleClass"
+underlying  = "int"
+
+[[enums.values]]
+name  = "Sedan"
+value = 0
+
+[[enums.values]]
+name  = "SUV"
+value = 1
+```
+
+Running `rexglue codegen project.toml` writes
+`generated/mappings_generated/types.h` and
+`generated/mappings_generated/enums.h` alongside the recompiled
+`.cpp` files, and logs:
+
+```
+[info] [codegen] Loaded 1 type definitions for header emission
+[info] [codegen] Loaded 1 enum definitions for header emission
+[info] [codegen] [type-headers] wrote generated/mappings_generated/types.h (1 types)
+[info] [codegen] [type-headers] wrote generated/mappings_generated/enums.h (1 enums)
+```
+
+## Out of scope (future work)
+
+- **Named-field emission.** A future opt-in mode that parses
+  producer type expressions, topologically sorts UDTs, and emits
+  real `struct Foo { _BAR baz; };` definitions. Substantial
+  parser + ordering work; tracked separately. Until landed, host
+  code uses the `<Type>_offsets` namespace.
+- **Static-assert per field offset.** Possible to emit
+  `static_assert(<Type>_offsets::Foo == 0xN)` for each field, but
+  redundant with the `inline constexpr` value itself.
+- **Unique-name as identifier fallback.** Use the producer's
+  `unique_name` (`U_KTHREAD@@`, `T0x471`) to rescue anonymous
+  types. The resulting identifiers are usually useless without
+  surrounding parent context; defer until host code shows it
+  actually wants them.
+
+## Compatibility
+
+- Default behaviour is unchanged when neither `[[types]]` nor
+  `[[enums]]` is configured. The emit step is a no-op.
+- Generated headers live in `mappings_generated/` so consumers
+  that don't `#include` them are unaffected.
+- The sanitized-identifier scheme is stable: same input config
+  produces the same headers byte-for-byte. Re-runs are idempotent.

--- a/include/rex/codegen/config.h
+++ b/include/rex/codegen/config.h
@@ -22,6 +22,55 @@
 
 namespace rex::codegen {
 
+// One field inside a [[types]] entry. The `type_expr` is the raw
+// MSVC type expression from the producer (e.g. `unsigned long:2`,
+// `void(_KTHREAD*, unsigned long)*`); it is preserved verbatim and
+// emitted as a comment beside the offset constant. The emitter does
+// not parse type expressions -- translating them into self-consistent
+// C++ would require a dialect-aware parser plus dependency-sorting
+// tens of thousands of UDTs, which is intentionally deferred.
+struct RecompilerTypeField {
+  std::string name;
+  std::string typeExpr;
+  uint32_t offset = 0;
+};
+
+// One [[types]] entry. Pairs with the producer schema documented in
+// docs/types_and_enums.md. `kind` carries `struct` / `union` /
+// `class` as a comment-only marker -- the emitter always produces an
+// opaque `struct` of the right size regardless. `size` is reproduced
+// in the generated header as `static_assert(sizeof(T) == size)`, so
+// any drift between producer and reality fails the compile.
+struct RecompilerType {
+  std::string name;        // sanitized C++ identifier
+  std::string rawName;     // original producer display name (header comment)
+  std::string uniqueName;  // optional dedupe / debug hint
+  std::string kind;        // "struct" | "union" | "class"
+  uint32_t size = 0;
+  std::vector<RecompilerTypeField> fields;
+};
+
+// One enumerator inside a [[enums]] entry. `value` is signed-widened
+// so it accommodates either signed or unsigned underlyings without
+// information loss; narrowing into the chosen `enum class` underlying
+// happens at emission time.
+struct RecompilerEnumValue {
+  std::string name;
+  int64_t value = 0;
+};
+
+// One [[enums]] entry. `underlying` is the producer's integer-type
+// string (`int`, `unsigned long`, `char`, ...); the emitter maps it
+// to a fixed-width type for `enum class : T`. Defaults to `int` per
+// the MSVC convention if the producer omits it.
+struct RecompilerEnum {
+  std::string name;        // sanitized C++ identifier
+  std::string rawName;
+  std::string uniqueName;
+  std::string underlying;  // raw producer string, mapped at emit time
+  std::vector<RecompilerEnumValue> values;
+};
+
 struct MidAsmHook {
   std::string name;
   std::vector<std::string> registers;
@@ -99,6 +148,16 @@ struct RecompilerConfig {
   std::unordered_map<uint32_t, FunctionConfig> functions;  ///< Function/chunk configuration
   std::unordered_map<uint32_t, JumpTable> switchTables;
   std::unordered_map<uint32_t, MidAsmHook> midAsmHooks;
+
+  /// Type / enum overrides loaded from `[[types]]` / `[[enums]]`
+  /// arrays in the user's config (or any included file). Consumed
+  /// by EmitTypeHeaders() which writes
+  /// `<outDirectoryPath>/mappings_generated/{types,enums}.h` when
+  /// either vector is non-empty. Empty when no producer config
+  /// supplies them (emit step becomes a no-op). See
+  /// `docs/types_and_enums.md` for the schema.
+  std::vector<RecompilerType> types;
+  std::vector<RecompilerEnum> enums;
   uint32_t longJmpAddress = 0;
   uint32_t setJmpAddress = 0;
 

--- a/include/rex/codegen/emit_type_headers.h
+++ b/include/rex/codegen/emit_type_headers.h
@@ -1,0 +1,41 @@
+/**
+ * @file        rex/codegen/emit_type_headers.h
+ * @brief       Type / enum header emission from RecompilerConfig
+ *
+ * @copyright   Copyright (c) 2026 Tom Clay
+ *              All rights reserved.
+ *
+ * @license     BSD 3-Clause License
+ *              See LICENSE file in the project root for full license text.
+ */
+
+#pragma once
+
+#include <filesystem>
+
+namespace rex::codegen {
+
+class CodegenContext;
+
+/**
+ * Emit `<outDir>/mappings_generated/{types,enums}.h` from
+ * `cfg.types` / `cfg.enums`.
+ *
+ * No-op when both vectors are empty (the default for projects that
+ * do not configure `[[types]]` / `[[enums]]`).
+ *
+ * Header layout: each `RecompilerType` becomes an opaque
+ * `struct <name> { unsigned char _opaque[size]; };` plus a sibling
+ * `<name>_offsets` namespace of `inline constexpr size_t` field
+ * offsets and a `static_assert(sizeof(<name>) == size)` drift check.
+ * Each `RecompilerEnum` becomes an `enum class <name> :
+ * <fixed_width_underlying>` with sanitized enumerators. See
+ * `docs/types_and_enums.md` for the full schema and rationale.
+ *
+ * Output directory is `configDir / cfg.outDirectoryPath /
+ * "mappings_generated"`. Created if missing; emission errors are
+ * logged but do not abort codegen.
+ */
+void EmitTypeHeaders(const CodegenContext& ctx);
+
+}  // namespace rex::codegen

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CODEGEN_CORE_SOURCES
     phase_gapfill.cpp
     phase_merge.cpp
     phase_validate.cpp
+    emit_type_headers.cpp
     template_registry.cpp
 )
 

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -14,6 +14,7 @@
 #include <rex/codegen/analyze.h>
 #include <rex/codegen/codegen.h>
 #include <rex/codegen/codegen_writer.h>
+#include <rex/codegen/emit_type_headers.h>
 #include <rex/kernel/init.h>
 #include <rex/logging.h>
 #include <rex/runtime.h>
@@ -86,6 +87,13 @@ Result<void> CodegenPipeline::Run(bool force) {
     }
     REXLOG_WARN("Analysis errors ignored due to --force; output may be incomplete");
   }
+
+  // Phase 1.5: Emit type / enum headers if the config supplied them.
+  // Independent of the analyzer (types come from config, not the
+  // binary) but placed here so a single codegen invocation produces
+  // self-consistent output. No-op when no [[types]] / [[enums]] are
+  // configured.
+  EmitTypeHeaders(*ctx_);
 
   // Phase 2: Generate C++ output
   CodegenWriter writer(*ctx_, runtime_.get());

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -81,7 +81,10 @@ Result<void> CodegenPipeline::Run(bool force) {
   auto analyzeResult = Analyze(*ctx_);
   if (!analyzeResult) {
     REXLOG_ERROR("Analysis failed: {}", analyzeResult.error().message);
-    return analyzeResult;
+    if (!force) {
+      return analyzeResult;
+    }
+    REXLOG_WARN("Analysis errors ignored due to --force; output may be incomplete");
   }
 
   // Phase 2: Generate C++ output

--- a/src/codegen/config.cpp
+++ b/src/codegen/config.cpp
@@ -32,6 +32,42 @@ namespace {
 /// Maximum nesting depth for include chains.
 constexpr uint32_t kMaxIncludeDepth = 32;
 
+// Sanitize a producer-supplied type / enum display name into a C++
+// identifier. Same opinion as the function-name sanitizer except no
+// address suffix (types and enums are name-keyed, not address-keyed)
+// and a hard reject for anonymous PDB tags (`<unnamed-tag>`,
+// `<unnamed-type-foo>`) -- those cannot be surfaced at file scope
+// without a synthesized stable identifier, and the producer doesn't
+// give us one for the leaf shape. Returns empty string when the
+// input cannot be sanitized; callers count and report.
+std::string SanitizeTypeName(std::string_view raw) {
+  if (raw.empty())
+    return {};
+  if (raw.front() == '<')
+    return {};
+
+  std::string out;
+  out.reserve(raw.size());
+  for (size_t i = 0; i < raw.size();) {
+    if (i + 1 < raw.size() && raw[i] == ':' && raw[i + 1] == ':') {
+      out.append("__");
+      i += 2;
+    } else {
+      out.push_back(raw[i]);
+      ++i;
+    }
+  }
+  for (char& c : out) {
+    const bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                    (c >= '0' && c <= '9') || c == '_';
+    if (!ok)
+      c = '_';
+  }
+  if (out.empty() || (out[0] >= '0' && out[0] <= '9'))
+    return {};
+  return out;
+}
+
 /// Parse a hex address string (with or without "0x"/"0X" prefix).
 std::optional<uint32_t> ParseHexAddress(const std::string& keyStr) {
   try {
@@ -372,6 +408,136 @@ void ApplyToml(const toml::table& toml, RecompilerConfig& cfg, const std::string
     }
   }
 
+  // [[types]] -- producer-supplied PDB-derived type entries; consumed
+  // by EmitTypeHeaders() to write mappings_generated/types.h. Schema
+  // documented in docs/types_and_enums.md. Each entry is keyed
+  // logically by `name` (sanitized -> C++ identifier); duplicates
+  // after sanitization are dropped first-wins (matches the producer
+  // declaration order). Anonymous PDB tags (`<unnamed-tag>`, ...)
+  // cannot be surfaced at file scope and are skipped.
+  if (auto typesArray = toml["types"].as_array()) {
+    std::unordered_set<std::string> seenTypeNames;
+    for (const auto& existing : cfg.types)
+      seenTypeNames.insert(existing.name);
+
+    size_t added = 0;
+    size_t skipped = 0;
+    size_t collisions = 0;
+    for (auto& entry : *typesArray) {
+      auto* table = entry.as_table();
+      if (!table) {
+        ++skipped;
+        continue;
+      }
+
+      auto rawName = (*table)["name"].value<std::string>().value_or("");
+      auto sanitized = SanitizeTypeName(rawName);
+      if (sanitized.empty()) {
+        ++skipped;
+        continue;
+      }
+
+      if (!seenTypeNames.insert(sanitized).second) {
+        ++collisions;
+        continue;
+      }
+
+      RecompilerType rt;
+      rt.name = std::move(sanitized);
+      rt.rawName = rawName;
+      rt.uniqueName = (*table)["unique_name"].value<std::string>().value_or("");
+      rt.kind = (*table)["kind"].value<std::string>().value_or("struct");
+      rt.size = (*table)["size"].value<uint32_t>().value_or(0u);
+
+      if (auto fieldArray = (*table)["fields"].as_array()) {
+        rt.fields.reserve(fieldArray->size());
+        for (auto& f : *fieldArray) {
+          auto* ft = f.as_table();
+          if (!ft)
+            continue;
+          RecompilerTypeField rf;
+          rf.name = (*ft)["name"].value<std::string>().value_or("");
+          rf.typeExpr = (*ft)["type_expr"].value<std::string>().value_or("");
+          rf.offset = (*ft)["offset"].value<uint32_t>().value_or(0u);
+          rt.fields.push_back(std::move(rf));
+        }
+      }
+
+      cfg.types.push_back(std::move(rt));
+      ++added;
+    }
+    if (added > 0 || skipped > 0 || collisions > 0) {
+      REXCODEGEN_DEBUG(
+          "[config]   [[types]] +{} from {}{}{}", added, filePath,
+          skipped ? fmt::format(" ({} skipped: anonymous or unsanitizable)", skipped) : std::string(),
+          collisions ? fmt::format(" ({} collisions dropped)", collisions) : std::string());
+    }
+  }
+
+  // [[enums]] -- producer-supplied PDB-derived enum entries;
+  // consumed by EmitTypeHeaders() to write
+  // mappings_generated/enums.h. Same dedupe / sanitization rules as
+  // [[types]]. Per-value dedupe (two enumerators with the same name
+  // would be a hard C++ error) happens at emission time.
+  if (auto enumsArray = toml["enums"].as_array()) {
+    std::unordered_set<std::string> seenEnumNames;
+    for (const auto& existing : cfg.enums)
+      seenEnumNames.insert(existing.name);
+
+    size_t added = 0;
+    size_t skipped = 0;
+    size_t collisions = 0;
+    for (auto& entry : *enumsArray) {
+      auto* table = entry.as_table();
+      if (!table) {
+        ++skipped;
+        continue;
+      }
+
+      auto rawName = (*table)["name"].value<std::string>().value_or("");
+      auto sanitized = SanitizeTypeName(rawName);
+      if (sanitized.empty()) {
+        ++skipped;
+        continue;
+      }
+
+      if (!seenEnumNames.insert(sanitized).second) {
+        ++collisions;
+        continue;
+      }
+
+      RecompilerEnum re;
+      re.name = std::move(sanitized);
+      re.rawName = rawName;
+      re.uniqueName = (*table)["unique_name"].value<std::string>().value_or("");
+      re.underlying = (*table)["underlying"].value<std::string>().value_or("int");
+
+      if (auto valueArray = (*table)["values"].as_array()) {
+        re.values.reserve(valueArray->size());
+        for (auto& v : *valueArray) {
+          auto* vt = v.as_table();
+          if (!vt)
+            continue;
+          RecompilerEnumValue rv;
+          rv.name = (*vt)["name"].value<std::string>().value_or("");
+          rv.value = (*vt)["value"].value<int64_t>().value_or(0);
+          if (rv.name.empty())
+            continue;
+          re.values.push_back(std::move(rv));
+        }
+      }
+
+      cfg.enums.push_back(std::move(re));
+      ++added;
+    }
+    if (added > 0 || skipped > 0 || collisions > 0) {
+      REXCODEGEN_DEBUG(
+          "[config]   [[enums]] +{} from {}{}{}", added, filePath,
+          skipped ? fmt::format(" ({} skipped: anonymous or unsanitizable)", skipped) : std::string(),
+          collisions ? fmt::format(" ({} collisions dropped)", collisions) : std::string());
+    }
+  }
+
   // --- Sets: additive ---
 
   // indirect_calls -> knownIndirectCallHints (set)
@@ -474,6 +640,12 @@ bool RecompilerConfig::Load(const std::string_view& configFilePath) {
     }
     REXCODEGEN_INFO("Loaded {} function configs ({} standalone, {} chunks)", functions.size(),
                     functions.size() - chunks_count, chunks_count);
+  }
+  if (!types.empty()) {
+    REXCODEGEN_INFO("Loaded {} type definitions for header emission", types.size());
+  }
+  if (!enums.empty()) {
+    REXCODEGEN_INFO("Loaded {} enum definitions for header emission", enums.size());
   }
 
   // Deduplicate exceptionHandlerFuncHints (push_back from multiple files)

--- a/src/codegen/emit_type_headers.cpp
+++ b/src/codegen/emit_type_headers.cpp
@@ -1,0 +1,271 @@
+/**
+ * @file        codegen/emit_type_headers.cpp
+ * @brief       Type / enum header emission from RecompilerConfig
+ *
+ * @copyright   Copyright (c) 2026 Tom Clay
+ *              All rights reserved.
+ *
+ * @license     BSD 3-Clause License
+ *              See LICENSE file in the project root for full license text.
+ *
+ * @remarks     Conservative opaque-storage emission. Each producer
+ *              type becomes an opaque struct sized to the producer's
+ *              `size` field, with field offsets exposed via a sibling
+ *              `<Type>_offsets` namespace. We deliberately do not
+ *              translate the producer's MSVC type expressions into
+ *              real C++ types -- that would require a dialect-aware
+ *              parser plus dependency-sorting tens of thousands of
+ *              UDTs, and is intentionally deferred. Field offsets
+ *              cover the host substrate's actual need: replacing
+ *              `blob + 0x40` with `<Type>_offsets::FieldName`.
+ */
+
+#include <rex/codegen/emit_type_headers.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+#include <fmt/format.h>
+
+#include <rex/codegen/codegen_context.h>
+#include <rex/codegen/config.h>
+#include <rex/logging.h>
+
+#include "codegen_logging.h"
+
+namespace rex::codegen {
+
+namespace {
+
+// Translate a producer-supplied enum underlying type string to a
+// fixed-width C++ identifier. The Xbox 360 ABI maps `long` to 32
+// bits, matching MSVC PPC. Anything we don't recognise falls back to
+// int32_t (matches MSVC's default enum underlying).
+std::string_view EnumUnderlying(std::string_view raw) {
+  if (raw == "char") return "int8_t";
+  if (raw == "unsigned char") return "uint8_t";
+  if (raw == "short") return "int16_t";
+  if (raw == "unsigned short") return "uint16_t";
+  if (raw == "int") return "int32_t";
+  if (raw == "unsigned int") return "uint32_t";
+  if (raw == "long") return "int32_t";
+  if (raw == "unsigned long") return "uint32_t";
+  if (raw == "__int64") return "int64_t";
+  if (raw == "unsigned __int64") return "uint64_t";
+  if (raw == "bool") return "bool";
+  return "int32_t";
+}
+
+// Re-escape a raw producer type expression for use inside a C++
+// comment. PDB strings can contain `*/` literals (function-pointer
+// return types like `void(...)*`), so collapse `*/` to `* /` to
+// prevent the comment from terminating early.
+std::string EscapeComment(std::string_view raw) {
+  std::string out;
+  out.reserve(raw.size());
+  for (size_t i = 0; i < raw.size(); ++i) {
+    if (i + 1 < raw.size() && raw[i] == '*' && raw[i + 1] == '/') {
+      out.append("* /");
+      ++i;
+    } else {
+      out.push_back(raw[i]);
+    }
+  }
+  return out;
+}
+
+// Sanitize an enum value name. Producer values are typically already
+// C identifiers but some include characters like `:` (anonymous
+// nested values) that need flattening. C++ keywords are not guarded
+// at this level -- enum values are conventionally upper-case in MSVC
+// headers and collisions don't arise in practice.
+std::string SanitizeEnumValue(std::string_view raw) {
+  std::string out;
+  out.reserve(raw.size());
+  for (char c : raw) {
+    const bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                    (c >= '0' && c <= '9') || c == '_';
+    out.push_back(ok ? c : '_');
+  }
+  if (out.empty() || (out[0] >= '0' && out[0] <= '9'))
+    return {};
+  return out;
+}
+
+// C++ keywords that must not appear as identifiers. Producer field
+// names sometimes match these (e.g. `register`, `namespace`, `not`
+// observed in real PDBs); without the guard the generated header
+// would fail to compile. Includes the C alternative tokens
+// defensively (GCC-strict mode rejects them as identifiers even
+// though clang accepts them by default).
+bool IsCppKeyword(std::string_view s) {
+  static const std::unordered_set<std::string_view> kw = {
+      "alignas",      "alignof",     "and",          "and_eq",       "asm",          "auto",
+      "bitand",       "bitor",       "bool",         "break",        "case",         "catch",
+      "char",         "char8_t",     "char16_t",     "char32_t",     "class",        "compl",
+      "concept",      "const",       "consteval",   "constexpr",    "constinit",    "const_cast",
+      "continue",     "co_await",    "co_return",   "co_yield",     "decltype",     "default",
+      "delete",       "do",          "double",       "dynamic_cast", "else",         "enum",
+      "explicit",     "export",      "extern",       "false",        "float",        "for",
+      "friend",       "goto",        "if",           "inline",       "int",          "long",
+      "mutable",      "namespace",   "new",          "noexcept",     "not",          "not_eq",
+      "nullptr",      "operator",    "or",           "or_eq",        "private",      "protected",
+      "public",       "register",    "reinterpret_cast",            "requires",     "return",
+      "short",        "signed",      "sizeof",       "static",       "static_assert",
+      "static_cast",  "struct",      "switch",       "template",     "this",         "thread_local",
+      "throw",        "true",        "try",          "typedef",      "typeid",       "typename",
+      "union",        "unsigned",    "using",        "virtual",      "void",         "volatile",
+      "wchar_t",      "while",       "xor",          "xor_eq",
+  };
+  return kw.count(s) != 0;
+}
+
+// Sanitize a struct field name. Same rule as enum value plus a C++
+// keyword guard: anything matching a reserved word gets an `f_`
+// prefix so the generated header always parses.
+std::string SanitizeFieldName(std::string_view raw) {
+  auto out = SanitizeEnumValue(raw);
+  if (out.empty())
+    return out;
+  if (IsCppKeyword(out))
+    out.insert(0, "f_");
+  return out;
+}
+
+}  // namespace
+
+void EmitTypeHeaders(const CodegenContext& ctx) {
+  const auto& cfg = ctx.Config();
+  if (cfg.types.empty() && cfg.enums.empty())
+    return;
+
+  std::filesystem::path outDir =
+      ctx.configDir() / cfg.outDirectoryPath / "mappings_generated";
+  std::error_code ec;
+  std::filesystem::create_directories(outDir, ec);
+  if (ec) {
+    REXCODEGEN_ERROR("[type-headers] failed to create {}: {}", outDir.string(), ec.message());
+    return;
+  }
+
+  // ---- types.h --------------------------------------------------
+  if (!cfg.types.empty()) {
+    std::string buf;
+    buf.reserve(cfg.types.size() * 256);
+    fmt::format_to(std::back_inserter(buf),
+                   "// Generated by ReXGlue from project config.\n"
+                   "// Do not edit; regenerate by re-running codegen.\n"
+                   "// Schema: docs/types_and_enums.md\n"
+                   "#pragma once\n"
+                   "\n"
+                   "#include <cstddef>\n"
+                   "#include <cstdint>\n"
+                   "\n");
+
+    size_t emittedTypes = 0;
+    for (const auto& t : cfg.types) {
+      // Opaque-storage emission: expose size + per-field offsets,
+      // do not translate the producer's MSVC type expressions into
+      // real C++ types. See the file-level remarks for rationale.
+      fmt::format_to(std::back_inserter(buf),
+                     "// {} (kind={}, unique_name={})\n"
+                     "struct {} {{\n"
+                     "    unsigned char _opaque[0x{:X}];\n"
+                     "}};\n",
+                     EscapeComment(t.rawName), t.kind, EscapeComment(t.uniqueName), t.name,
+                     t.size == 0 ? 1u : t.size);
+
+      // Only enforce sizeof when the producer reported a non-zero
+      // size. Forward-declared / zero-sized PDB types report
+      // size==0; emitting a static_assert there would either pass
+      // trivially (sizeof always >= 1) or fail spuriously.
+      if (t.size > 0) {
+        fmt::format_to(std::back_inserter(buf),
+                       "static_assert(sizeof({}) == 0x{:X}, \"{} size mismatch with producer\");\n",
+                       t.name, t.size, t.name);
+      }
+
+      if (!t.fields.empty()) {
+        fmt::format_to(std::back_inserter(buf), "namespace {}_offsets {{\n", t.name);
+        std::unordered_set<std::string> seenFields;
+        for (const auto& f : t.fields) {
+          auto fname = SanitizeFieldName(f.name);
+          if (fname.empty())
+            continue;
+          // Anonymous unions surface multiple fields at the same
+          // offset; the header only needs one entry per unique
+          // sanitized name. First occurrence wins.
+          if (!seenFields.insert(fname).second)
+            continue;
+
+          fmt::format_to(std::back_inserter(buf),
+                         "    inline constexpr size_t {} = 0x{:X}; // {}\n", fname, f.offset,
+                         EscapeComment(f.typeExpr));
+        }
+        buf.append("}\n");
+      }
+      buf.push_back('\n');
+      ++emittedTypes;
+    }
+
+    auto path = (outDir / "types.h").string();
+    std::ofstream typesOut(path);
+    if (!typesOut) {
+      REXCODEGEN_ERROR("[type-headers] failed to open {} for writing", path);
+    } else {
+      typesOut << buf;
+      REXCODEGEN_INFO("[type-headers] wrote {} ({} types)", path, emittedTypes);
+    }
+  }
+
+  // ---- enums.h --------------------------------------------------
+  if (!cfg.enums.empty()) {
+    std::string buf;
+    buf.reserve(cfg.enums.size() * 128);
+    fmt::format_to(std::back_inserter(buf),
+                   "// Generated by ReXGlue from project config.\n"
+                   "// Do not edit; regenerate by re-running codegen.\n"
+                   "// Schema: docs/types_and_enums.md\n"
+                   "#pragma once\n"
+                   "\n"
+                   "#include <cstdint>\n"
+                   "\n");
+
+    size_t emittedEnums = 0;
+    for (const auto& e : cfg.enums) {
+      fmt::format_to(std::back_inserter(buf),
+                     "// {} (underlying={}, unique_name={})\n"
+                     "enum class {} : {} {{\n",
+                     EscapeComment(e.rawName), e.underlying, EscapeComment(e.uniqueName), e.name,
+                     EnumUnderlying(e.underlying));
+
+      std::unordered_set<std::string> seenValues;
+      for (const auto& v : e.values) {
+        auto vname = SanitizeEnumValue(v.name);
+        if (vname.empty())
+          continue;
+        // Two enumerators with the same name in one enum would be
+        // a hard C++ error; dedupe by name and keep the first.
+        if (!seenValues.insert(vname).second)
+          continue;
+        fmt::format_to(std::back_inserter(buf), "    {} = {},\n", vname, v.value);
+      }
+      buf.append("};\n\n");
+      ++emittedEnums;
+    }
+
+    auto path = (outDir / "enums.h").string();
+    std::ofstream enumsOut(path);
+    if (!enumsOut) {
+      REXCODEGEN_ERROR("[type-headers] failed to open {} for writing", path);
+    } else {
+      enumsOut << buf;
+      REXCODEGEN_INFO("[type-headers] wrote {} ({} enums)", path, emittedEnums);
+    }
+  }
+}
+
+}  // namespace rex::codegen


### PR DESCRIPTION
Closes #329.

> **Stacked on top of #327** (`--force` analyze fix). The diff against `main` includes the `--force` commit until #327 merges; once it does, GitHub will auto-rebase this PR and the diff will collapse to just the type/enum work.

## Summary

Add an emission step that materialises config-supplied `[[types]]` and `[[enums]]` arrays into two header files alongside the recompiled `.cpp` output:

```
<out_directory_path>/mappings_generated/types.h
<out_directory_path>/mappings_generated/enums.h
```

Each producer type becomes an opaque ` struct` with the right size, a sibling `<Name>_offsets` namespace of `inline constexpr size_t` field offsets, and a `static_assert(sizeof) == size` drift check. Each producer enum becomes an `enum class` with a fixed-width underlying type. Pure declarations — `<cstddef>` / `<cstdint>` only.

The motivation is the same one that drives `[functions]` overrides: a producer (typically a PDB extractor) carries layout / enum data alongside the function names, and we want the host substrate to address PPC-side data via named offset constants instead of hand-coded byte offsets:

```cpp
// before
*((uint8_t*)thread + 0x6D) = 0;

// after
*((uint8_t*)thread + _KTHREAD_offsets::Alerted) = 0;
```

Self-documenting, drift-detectable (the constant fails the build if the producer ever changes), zero-overhead at runtime.

## Schema

`[[types]]` and `[[enums]]` are top-level arrays-of-tables, parsed from any config file (main or included via `includes`), with the same merge semantics as `[[switch_tables]]` / `[[invalid_instructions]]`. Full schema reference is in `docs/types_and_enums.md` (added in this PR).

```toml
[[types]]
name        = "Vehicle"
unique_name = ".?AVVehicle@@"
kind        = "class"
size        = 0x80

[[types.fields]]
name      = "rpm"
type_expr = "float"
offset    = 0x10

[[enums]]
name        = "VehicleClass"
underlying  = "int"

[[enums.values]]
name  = "Sedan"
value = 0
```

## Design decisions

- **No new gate / CLI flag.** Emit when data is present, no-op when absent. Matches `[functions]` semantics — data drives behaviour, not a separate switch.
- **Schema lives in the existing config**, not a new `*_file_path` key. Use `includes` for layered configs.
- **Plural array names** (`[[types]]`, `[[enums]]`, `[[types.fields]]`, `[[enums.values]]`) to match rexglue's existing `[[switch_tables]]` / `[[invalid_instructions]]` idiom.
- **Opaque storage, not named-field translation.** Translating producer type expressions (`unsigned long:2`, `void(_KTHREAD*, unsigned long)*`) into self-consistent C++ requires dialect-aware parsing plus topological ordering of UDTs. Substantial; intentionally deferred. Field offsets cover the host substrate's actual need.
- **Sanitization with no address suffix.** Types and enums are name-keyed (unlike functions, which can share `display` names across overloads). Anonymous tags (`<unnamed-tag>`) are skipped. Sanitized-identifier collisions drop the second occurrence first-wins.

## Files

| File | Change |
|---|---|
| `include/rex/codegen/config.h` | Add `RecompilerType` / `RecompilerTypeField` / `RecompilerEnum` / `RecompilerEnumValue` structs and `types` / `enums` vectors on `RecompilerConfig`. |
| `src/codegen/config.cpp` | `SanitizeTypeName` helper; `[[types]]` / `[[enums]]` parsing in `ApplyToml`; post-load summary log lines. |
| `include/rex/codegen/emit_type_headers.h` | Public entry point declaration. |
| `src/codegen/emit_type_headers.cpp` | New file. `EmitTypeHeaders` body plus helpers (`EnumUnderlying`, `EscapeComment`, `SanitizeEnumValue`, `IsCppKeyword`, `SanitizeFieldName`). |
| `src/codegen/codegen.cpp` | Invoke `EmitTypeHeaders(*ctx_)` between Analyze and `CodegenWriter::write`. |
| `src/codegen/CMakeLists.txt` | Add `emit_type_headers.cpp` to the rexcodegen sources. |
| `docs/types_and_enums.md` | New user-facing schema reference. |

## Test plan

### Smoke test (hand-crafted fixture)

A small TOML fixture covers normal struct with fields, anonymous-tag skip, sanitized identifier collision drop, forward-declared (`size = 0`) type, scoped name (`::` → `__`), keyword guard on a field name (`register` → `f_register`), comment-escape-friendly `type_expr`, anonymous-union flattening (two fields at same offset, different names — both surface), sanitized enum value with weird chars, duplicate enum value drop, multiple integer underlyings (`int`, `unsigned char`, `bool`), and an empty enum.

```
[info] [codegen] Loaded 4 type definitions for header emission
[info] [codegen] Loaded 5 enum definitions for header emission
[info] [codegen] [type-headers] wrote out/mappings_generated/types.h (4 types)
[info] [codegen] [type-headers] wrote out/mappings_generated/enums.h (5 enums)
```

(One type collision-dropped, one anonymous-tag-skipped, three emitted; five enums all emitted.)

Generated headers compile clean:

```
$ clang++ -std=c++23 -c -o /dev/null types_enums_check.cpp -I out/mappings_generated/
$ echo $?
0
```

### Real-data validation

Pending downstream: a PDB extractor on our side is being extended to emit `[[types]]` / `[[enums]]` blocks on top of its existing `[functions]` output. Once that lands we'll have a real-data run to drop in here (~50k types, ~4k enums against the FH1 retail XEX) before merge.

## Compatibility

- Default behaviour unchanged when neither `[[types]]` nor `[[enums]]` is configured. No `mappings_generated/` directory is created.
- The sanitized-identifier scheme is stable: same input config produces the same headers byte-for-byte. Re-runs are idempotent.
- Existing config files are unaffected; older builds silently ignore the new top-level arrays.

## Out of scope

- **Named-field emission.** Future opt-in mode that parses producer type expressions, topologically sorts UDTs, and emits real `struct Foo { _BAR baz; };` definitions. Tracked separately.
- **Static-assert per field offset.** Possible but redundant with the `inline constexpr` value itself.