### PR TITLE
Add Discord Rich Presence (RPC) Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ add_subdirectory(src/graphics)
 add_subdirectory(src/system)
 add_subdirectory(src/kernel)
 add_subdirectory(src/codegen)
+add_subdirectory(src/discord)
 add_subdirectory(src/rexglue)
 
 # Add tests subdirectory if tests are enabled

--- a/include/rex/discord_rpc.h
+++ b/include/rex/discord_rpc.h
@@ -24,10 +24,10 @@
 namespace rex::discord_rpc {
 
 struct Presence {
-  std::string details_;          // first line under the title, e.g. "In Main Menu"
-  std::string state_;            // second line, e.g. "Level 196"
-  std::string large_image_key_;  // asset name from the Developer Portal
-  std::string large_image_text_; // tooltip shown on hover
+  std::string details_;           // first line under the title, e.g. "In Main Menu"
+  std::string state_;             // second line, e.g. "Level 196"
+  std::string large_image_key_;   // asset name from the Developer Portal
+  std::string large_image_text_;  // tooltip shown on hover
   std::string small_image_key_;
   std::string small_image_text_;
 };

--- a/include/rex/discord_rpc.h
+++ b/include/rex/discord_rpc.h
@@ -1,0 +1,52 @@
+/**
+ * @file        rex/discord_rpc.h
+ * @brief       Lightweight Discord Rich Presence client
+ *
+ * Communicates with the local Discord client over a named pipe (IPC) using a
+ * JSON payload — no third-party dependencies.
+ *
+ * To enable Rich Presence, create an Application at
+ * https://discord.com/developers/applications and pass its Application ID to
+ * Start(). Upload artwork there and reference asset names via SetLargeImage /
+ * SetSmallImage.
+ *
+ * @license     BSD 3-Clause License
+ *              See LICENSE file in the project root for full license text.
+ */
+#pragma once
+
+#include <string>
+
+#include <rex/platform.h>
+
+#if REX_PLATFORM_WIN32 || REX_PLATFORM_LINUX
+
+namespace rex::discord_rpc {
+
+struct Presence {
+  std::string details_;          // first line under the title, e.g. "In Main Menu"
+  std::string state_;            // second line, e.g. "Level 196"
+  std::string large_image_key_;  // asset name from the Developer Portal
+  std::string large_image_text_; // tooltip shown on hover
+  std::string small_image_key_;
+  std::string small_image_text_;
+};
+
+// Spawns a background worker thread (idempotent). Sets the initial presence.
+void Start(const char* client_id, const Presence& initial = {});
+
+// Replaces the entire presence
+void SetPresence(const Presence& p);
+
+// Per-field setters for incremental updates (avoids constructing a full Presence).
+void SetDetails(const std::string& details);
+void SetState(const std::string& state);
+void SetLargeImage(const std::string& key, const std::string& text = "");
+void SetSmallImage(const std::string& key, const std::string& text = "");
+
+// Stops the worker thread and clears the presence.
+void Stop();
+
+}  // namespace rex::discord_rpc
+
+#endif  // REX_PLATFORM_WIN32 || REX_PLATFORM_LINUX

--- a/src/discord/CMakeLists.txt
+++ b/src/discord/CMakeLists.txt
@@ -1,0 +1,16 @@
+# rexdiscord - Discord Rich Presence client
+# Windows and Linux only
+
+if(NOT WIN32 AND NOT LINUX)
+  return()
+endif()
+
+add_library(rexdiscord OBJECT discord_rpc.cpp)
+add_library(rex::discord ALIAS rexdiscord)
+
+target_include_directories(rexdiscord PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(rexdiscord PUBLIC rexcore)

--- a/src/discord/discord_rpc.cpp
+++ b/src/discord/discord_rpc.cpp
@@ -12,24 +12,24 @@
 #include <string>
 #include <thread>
 #if REX_PLATFORM_LINUX
-#  include <vector>
+#include <vector>
 #endif
 
 REXCVAR_DEFINE_BOOL(discord_activity, true, "Thirdparty", "Enable Discord Rich Presence activity");
 
 #if REX_PLATFORM_WIN32
-#  ifndef NOMINMAX
-#    define NOMINMAX
-#  endif
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
-#  endif
-#  include <Windows.h>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
 #elif REX_PLATFORM_LINUX
-#  include <sys/select.h>
-#  include <sys/socket.h>
-#  include <sys/un.h>
-#  include <unistd.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 #endif
 
 namespace rex::discord_rpc {
@@ -54,10 +54,14 @@ std::atomic<bool> g_dirty{false};
 
 #if REX_PLATFORM_WIN32
 HANDLE g_pipe = INVALID_HANDLE_VALUE;
-bool IsConnected() { return g_pipe != INVALID_HANDLE_VALUE; }
+bool IsConnected() {
+  return g_pipe != INVALID_HANDLE_VALUE;
+}
 #elif REX_PLATFORM_LINUX
 int g_sock = -1;
-bool IsConnected() { return g_sock != -1; }
+bool IsConnected() {
+  return g_sock != -1;
+}
 #endif
 
 #if REX_PLATFORM_WIN32
@@ -66,8 +70,8 @@ bool ConnectToDiscord() {
   for (int i = 0; i < 10; ++i) {
     char name[64];
     std::snprintf(name, sizeof(name), "\\\\.\\pipe\\discord-ipc-%d", i);
-    HANDLE h = ::CreateFileA(name, GENERIC_READ | GENERIC_WRITE, 0, nullptr,
-                             OPEN_EXISTING, 0, nullptr);
+    HANDLE h =
+        ::CreateFileA(name, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
     if (h != INVALID_HANDLE_VALUE) {
       g_pipe = h;
       return true;
@@ -136,12 +140,11 @@ bool WriteFrame(uint32_t op, const std::string& payload) {
     return false;
   uint32_t header[2] = {op, static_cast<uint32_t>(payload.size())};
   DWORD written = 0;
-  if (!::WriteFile(g_pipe, header, sizeof(header), &written, nullptr) ||
-      written != sizeof(header))
+  if (!::WriteFile(g_pipe, header, sizeof(header), &written, nullptr) || written != sizeof(header))
     return false;
   if (!payload.empty()) {
-    if (!::WriteFile(g_pipe, payload.data(), static_cast<DWORD>(payload.size()),
-                     &written, nullptr) ||
+    if (!::WriteFile(g_pipe, payload.data(), static_cast<DWORD>(payload.size()), &written,
+                     nullptr) ||
         written != payload.size())
       return false;
   }
@@ -189,8 +192,7 @@ void DrainMessages(bool* out_ready = nullptr) {
       return;
     uint32_t header[2] = {0, 0};
     DWORD read = 0;
-    if (!::ReadFile(g_pipe, header, sizeof(header), &read, nullptr) ||
-        read != sizeof(header))
+    if (!::ReadFile(g_pipe, header, sizeof(header), &read, nullptr) || read != sizeof(header))
       return;
     std::string buf;
     if (header[1] > 0) {
@@ -198,8 +200,7 @@ void DrainMessages(bool* out_ready = nullptr) {
       DWORD total = 0;
       while (total < header[1]) {
         DWORD n = 0;
-        if (!::ReadFile(g_pipe, buf.data() + total, header[1] - total, &n, nullptr) ||
-            n == 0)
+        if (!::ReadFile(g_pipe, buf.data() + total, header[1] - total, &n, nullptr) || n == 0)
           return;
         total += n;
       }
@@ -274,10 +275,16 @@ void DrainMessages(bool* out_ready = nullptr) {
 #endif  // DrainMessages
 
 #if REX_PLATFORM_WIN32
-uint32_t GetPid() { return static_cast<uint32_t>(::GetCurrentProcessId()); }
-std::string GetNonce() { return std::to_string(::GetTickCount()); }
+uint32_t GetPid() {
+  return static_cast<uint32_t>(::GetCurrentProcessId());
+}
+std::string GetNonce() {
+  return std::to_string(::GetTickCount());
+}
 #elif REX_PLATFORM_LINUX
-uint32_t GetPid() { return static_cast<uint32_t>(::getpid()); }
+uint32_t GetPid() {
+  return static_cast<uint32_t>(::getpid());
+}
 std::string GetNonce() {
   return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::steady_clock::now().time_since_epoch())
@@ -290,13 +297,27 @@ std::string JsonEscape(const std::string& in) {
   out.reserve(in.size() + 2);
   for (char c : in) {
     switch (c) {
-      case '"':  out += "\\\""; break;
-      case '\\': out += "\\\\"; break;
-      case '\b': out += "\\b";  break;
-      case '\f': out += "\\f";  break;
-      case '\n': out += "\\n";  break;
-      case '\r': out += "\\r";  break;
-      case '\t': out += "\\t";  break;
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\b':
+        out += "\\b";
+        break;
+      case '\f':
+        out += "\\f";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
       default:
         if (static_cast<unsigned char>(c) < 0x20) {
           char hex[8];
@@ -325,8 +346,7 @@ bool SendClearActivity() {
 }
 
 bool SendActivity(const Presence& p, int64_t start_timestamp) {
-  auto appendStr = [](std::string& dst, bool& first, const char* key,
-                      const std::string& val) {
+  auto appendStr = [](std::string& dst, bool& first, const char* key, const std::string& val) {
     if (val.empty())
       return;
     if (!first)

--- a/src/discord/discord_rpc.cpp
+++ b/src/discord/discord_rpc.cpp
@@ -1,0 +1,550 @@
+#include <rex/discord_rpc.h>
+#include <rex/cvar.h>
+#include <rex/logging.h>
+#include <rex/platform.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#if REX_PLATFORM_LINUX
+#  include <vector>
+#endif
+
+REXCVAR_DEFINE_BOOL(discord_activity, true, "Thirdparty", "Enable Discord Rich Presence activity");
+
+#if REX_PLATFORM_WIN32
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <Windows.h>
+#elif REX_PLATFORM_LINUX
+#  include <sys/select.h>
+#  include <sys/socket.h>
+#  include <sys/un.h>
+#  include <unistd.h>
+#endif
+
+namespace rex::discord_rpc {
+
+namespace {
+
+// IPC frame opcodes defined by the Discord RPC protocol.
+enum : uint32_t {
+  kOpHandshake = 0,
+  kOpFrame = 1,
+  kOpClose = 2,
+  kOpPing = 3,
+  kOpPong = 4,
+};
+
+std::atomic<bool> g_running{false};
+std::thread g_thread;
+std::mutex g_mutex;
+Presence g_presence;
+std::string g_client_id;
+std::atomic<bool> g_dirty{false};
+
+#if REX_PLATFORM_WIN32
+HANDLE g_pipe = INVALID_HANDLE_VALUE;
+bool IsConnected() { return g_pipe != INVALID_HANDLE_VALUE; }
+#elif REX_PLATFORM_LINUX
+int g_sock = -1;
+bool IsConnected() { return g_sock != -1; }
+#endif
+
+#if REX_PLATFORM_WIN32
+
+bool ConnectToDiscord() {
+  for (int i = 0; i < 10; ++i) {
+    char name[64];
+    std::snprintf(name, sizeof(name), "\\\\.\\pipe\\discord-ipc-%d", i);
+    HANDLE h = ::CreateFileA(name, GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                             OPEN_EXISTING, 0, nullptr);
+    if (h != INVALID_HANDLE_VALUE) {
+      g_pipe = h;
+      return true;
+    }
+  }
+  REXLOG_WARN("DiscordRPC: no Discord IPC pipe found (is Discord running?)");
+  return false;
+}
+
+void CloseConnection() {
+  if (g_pipe != INVALID_HANDLE_VALUE) {
+    ::CloseHandle(g_pipe);
+    g_pipe = INVALID_HANDLE_VALUE;
+  }
+}
+
+#elif REX_PLATFORM_LINUX
+
+std::vector<std::string> GetSocketDirs() {
+  std::vector<std::string> dirs;
+  const char* xdg = std::getenv("XDG_RUNTIME_DIR");
+  if (xdg && *xdg)
+    dirs.push_back(xdg);
+  const char* tmp = std::getenv("TMPDIR");
+  if (tmp && *tmp)
+    dirs.push_back(tmp);
+  dirs.push_back("/run/user/" + std::to_string(::getuid()));
+  dirs.push_back("/tmp");
+  return dirs;
+}
+
+bool ConnectToDiscord() {
+  for (const auto& dir : GetSocketDirs()) {
+    for (int i = 0; i < 10; ++i) {
+      std::string path = dir + "/discord-ipc-" + std::to_string(i);
+      int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+      if (fd == -1)
+        continue;
+      sockaddr_un addr{};
+      addr.sun_family = AF_UNIX;
+      std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+      if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+        g_sock = fd;
+        return true;
+      }
+      ::close(fd);
+    }
+  }
+  REXLOG_WARN("DiscordRPC: no Discord IPC socket found (is Discord running?)");
+  return false;
+}
+
+void CloseConnection() {
+  if (g_sock != -1) {
+    ::close(g_sock);
+    g_sock = -1;
+  }
+}
+
+#endif  // connect/close
+
+#if REX_PLATFORM_WIN32
+
+bool WriteFrame(uint32_t op, const std::string& payload) {
+  if (!IsConnected())
+    return false;
+  uint32_t header[2] = {op, static_cast<uint32_t>(payload.size())};
+  DWORD written = 0;
+  if (!::WriteFile(g_pipe, header, sizeof(header), &written, nullptr) ||
+      written != sizeof(header))
+    return false;
+  if (!payload.empty()) {
+    if (!::WriteFile(g_pipe, payload.data(), static_cast<DWORD>(payload.size()),
+                     &written, nullptr) ||
+        written != payload.size())
+      return false;
+  }
+  return true;
+}
+
+#elif REX_PLATFORM_LINUX
+
+bool WriteAll(const void* buf, size_t len) {
+  const char* ptr = static_cast<const char*>(buf);
+  while (len > 0) {
+    ssize_t n = ::write(g_sock, ptr, len);
+    if (n <= 0)
+      return false;
+    ptr += n;
+    len -= static_cast<size_t>(n);
+  }
+  return true;
+}
+
+bool WriteFrame(uint32_t op, const std::string& payload) {
+  if (!IsConnected())
+    return false;
+  uint32_t header[2] = {op, static_cast<uint32_t>(payload.size())};
+  if (!WriteAll(header, sizeof(header)))
+    return false;
+  if (!payload.empty())
+    if (!WriteAll(payload.data(), payload.size()))
+      return false;
+  return true;
+}
+
+#endif  // WriteFrame
+
+#if REX_PLATFORM_WIN32
+
+void DrainMessages(bool* out_ready = nullptr) {
+  if (!IsConnected())
+    return;
+  while (true) {
+    DWORD avail = 0;
+    if (!::PeekNamedPipe(g_pipe, nullptr, 0, nullptr, &avail, nullptr))
+      return;
+    if (avail < 8)
+      return;
+    uint32_t header[2] = {0, 0};
+    DWORD read = 0;
+    if (!::ReadFile(g_pipe, header, sizeof(header), &read, nullptr) ||
+        read != sizeof(header))
+      return;
+    std::string buf;
+    if (header[1] > 0) {
+      buf.resize(header[1]);
+      DWORD total = 0;
+      while (total < header[1]) {
+        DWORD n = 0;
+        if (!::ReadFile(g_pipe, buf.data() + total, header[1] - total, &n, nullptr) ||
+            n == 0)
+          return;
+        total += n;
+      }
+    }
+    if (header[0] == kOpPing) {
+      WriteFrame(kOpPong, buf);
+    } else if (header[0] == kOpFrame) {
+      if (out_ready && buf.find("\"evt\":\"READY\"") != std::string::npos)
+        *out_ready = true;
+    } else if (header[0] == kOpClose) {
+      REXLOG_WARN("DiscordRPC: server closed: {}", buf);
+      CloseConnection();
+      return;
+    }
+  }
+}
+
+#elif REX_PLATFORM_LINUX
+
+bool ReadAll(void* buf, size_t len) {
+  char* ptr = static_cast<char*>(buf);
+  while (len > 0) {
+    ssize_t n = ::recv(g_sock, ptr, len, 0);
+    if (n <= 0)
+      return false;
+    ptr += n;
+    len -= static_cast<size_t>(n);
+  }
+  return true;
+}
+
+bool HasData() {
+  if (!IsConnected())
+    return false;
+  fd_set fds;
+  FD_ZERO(&fds);
+  FD_SET(g_sock, &fds);
+  timeval tv{0, 0};
+  return ::select(g_sock + 1, &fds, nullptr, nullptr, &tv) > 0;
+}
+
+void DrainMessages(bool* out_ready = nullptr) {
+  if (!IsConnected())
+    return;
+  while (HasData()) {
+    uint32_t header[2] = {0, 0};
+    if (!ReadAll(header, sizeof(header))) {
+      CloseConnection();
+      return;
+    }
+    std::string buf;
+    if (header[1] > 0) {
+      buf.resize(header[1]);
+      if (!ReadAll(buf.data(), header[1])) {
+        CloseConnection();
+        return;
+      }
+    }
+    if (header[0] == kOpPing) {
+      WriteFrame(kOpPong, buf);
+    } else if (header[0] == kOpFrame) {
+      if (out_ready && buf.find("\"evt\":\"READY\"") != std::string::npos)
+        *out_ready = true;
+    } else if (header[0] == kOpClose) {
+      REXLOG_WARN("DiscordRPC: server closed: {}", buf);
+      CloseConnection();
+      return;
+    }
+  }
+}
+
+#endif  // DrainMessages
+
+#if REX_PLATFORM_WIN32
+uint32_t GetPid() { return static_cast<uint32_t>(::GetCurrentProcessId()); }
+std::string GetNonce() { return std::to_string(::GetTickCount()); }
+#elif REX_PLATFORM_LINUX
+uint32_t GetPid() { return static_cast<uint32_t>(::getpid()); }
+std::string GetNonce() {
+  return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count());
+}
+#endif
+
+std::string JsonEscape(const std::string& in) {
+  std::string out;
+  out.reserve(in.size() + 2);
+  for (char c : in) {
+    switch (c) {
+      case '"':  out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\b': out += "\\b";  break;
+      case '\f': out += "\\f";  break;
+      case '\n': out += "\\n";  break;
+      case '\r': out += "\\r";  break;
+      case '\t': out += "\\t";  break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char hex[8];
+          std::snprintf(hex, sizeof(hex), "\\u%04x", c);
+          out += hex;
+        } else {
+          out += c;
+        }
+    }
+  }
+  return out;
+}
+
+bool SendHandshake() {
+  std::string payload = std::string("{\"v\":1,\"client_id\":\"") + g_client_id + "\"}";
+  return WriteFrame(kOpHandshake, payload);
+}
+
+bool SendClearActivity() {
+  std::string payload = "{\"cmd\":\"SET_ACTIVITY\",\"args\":{\"pid\":";
+  payload += std::to_string(GetPid());
+  payload += ",\"activity\":null},\"nonce\":\"";
+  payload += GetNonce();
+  payload += "\"}";
+  return WriteFrame(kOpFrame, payload);
+}
+
+bool SendActivity(const Presence& p, int64_t start_timestamp) {
+  auto appendStr = [](std::string& dst, bool& first, const char* key,
+                      const std::string& val) {
+    if (val.empty())
+      return;
+    if (!first)
+      dst += ",";
+    dst += "\"";
+    dst += key;
+    dst += "\":\"" + JsonEscape(val) + "\"";
+    first = false;
+  };
+
+  std::string assets;
+  {
+    bool first_a = true;
+    assets = "{";
+    appendStr(assets, first_a, "large_image", p.large_image_key_);
+    appendStr(assets, first_a, "large_text", p.large_image_text_);
+    appendStr(assets, first_a, "small_image", p.small_image_key_);
+    appendStr(assets, first_a, "small_text", p.small_image_text_);
+    assets += "}";
+    if (first_a)
+      assets.clear();
+  }
+
+  std::string activity = "{";
+  bool first = true;
+  appendStr(activity, first, "details", p.details_);
+  appendStr(activity, first, "state", p.state_);
+  if (start_timestamp > 0) {
+    if (!first)
+      activity += ",";
+    activity += "\"timestamps\":{\"start\":";
+    activity += std::to_string(start_timestamp);
+    activity += "}";
+    first = false;
+  }
+  if (!assets.empty()) {
+    if (!first)
+      activity += ",";
+    activity += "\"assets\":";
+    activity += assets;
+    first = false;
+  }
+  if (!first)
+    activity += ",";
+  activity += "\"instance\":false";
+  activity += "}";
+
+  std::string payload = "{\"cmd\":\"SET_ACTIVITY\",\"args\":{\"pid\":";
+  payload += std::to_string(GetPid());
+  payload += ",\"activity\":";
+  payload += activity;
+  payload += "},\"nonce\":\"";
+  payload += GetNonce();
+  payload += "\"}";
+  return WriteFrame(kOpFrame, payload);
+}
+
+void WorkerThread() {
+  using clock = std::chrono::steady_clock;
+  auto next_reconnect = clock::now();
+  int64_t start_timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+                                std::chrono::system_clock::now().time_since_epoch())
+                                .count();
+  bool handshake_sent = false;
+  bool ready = false;
+  bool last_activity_enabled = REXCVAR_GET(discord_activity);
+
+  while (g_running.load()) {
+    if (!IsConnected()) {
+      if (clock::now() < next_reconnect) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        continue;
+      }
+      if (!ConnectToDiscord()) {
+        next_reconnect = clock::now() + std::chrono::seconds(15);
+        continue;
+      }
+      handshake_sent = false;
+      ready = false;
+    }
+
+    if (!handshake_sent) {
+      if (!SendHandshake()) {
+        CloseConnection();
+        next_reconnect = clock::now() + std::chrono::seconds(15);
+        continue;
+      }
+      handshake_sent = true;
+    }
+
+    DrainMessages(&ready);
+
+    const bool activity_enabled = REXCVAR_GET(discord_activity);
+    if (activity_enabled != last_activity_enabled) {
+      last_activity_enabled = activity_enabled;
+      g_dirty = true;
+    }
+
+    if (ready && g_dirty.exchange(false)) {
+      if (activity_enabled) {
+        Presence snap;
+        {
+          std::lock_guard<std::mutex> lock(g_mutex);
+          snap = g_presence;
+        }
+        if (!SendActivity(snap, start_timestamp)) {
+          CloseConnection();
+          next_reconnect = clock::now() + std::chrono::seconds(5);
+          continue;
+        }
+      } else {
+        if (!SendClearActivity()) {
+          CloseConnection();
+          next_reconnect = clock::now() + std::chrono::seconds(5);
+          continue;
+        }
+      }
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  }
+
+  if (IsConnected()) {
+    SendClearActivity();
+    WriteFrame(kOpClose, "{}");
+    CloseConnection();
+  }
+}
+
+void SyncClearAndClose() {
+  if (!IsConnected())
+    return;
+  SendClearActivity();
+  WriteFrame(kOpClose, "{}");
+  CloseConnection();
+}
+
+#if REX_PLATFORM_WIN32
+BOOL WINAPI ConsoleCtrlHandler(DWORD) {
+  SyncClearAndClose();
+  return FALSE;
+}
+#endif
+
+struct AtExitInstaller {
+  AtExitInstaller() {
+    std::atexit([] { SyncClearAndClose(); });
+#if REX_PLATFORM_WIN32
+    ::SetConsoleCtrlHandler(ConsoleCtrlHandler, TRUE);
+#endif
+  }
+} g_atExitInstaller;
+
+}  // namespace
+
+void Start(const char* client_id, const Presence& initial) {
+  if (!client_id || *client_id == '\0') {
+    REXLOG_WARN("DiscordRPC: Start() called with null/empty client_id — skipping");
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_client_id = client_id;
+    g_presence = initial;
+  }
+  g_dirty = true;
+  if (g_running.exchange(true))
+    return;
+  g_thread = std::thread(WorkerThread);
+}
+
+void SetPresence(const Presence& p) {
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_presence = p;
+  }
+  g_dirty = true;
+}
+
+void SetDetails(const std::string& details) {
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_presence.details_ = details;
+  }
+  g_dirty = true;
+}
+
+void SetState(const std::string& state) {
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_presence.state_ = state;
+  }
+  g_dirty = true;
+}
+
+void SetLargeImage(const std::string& key, const std::string& text) {
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_presence.large_image_key_ = key;
+    g_presence.large_image_text_ = text;
+  }
+  g_dirty = true;
+}
+
+void SetSmallImage(const std::string& key, const std::string& text) {
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_presence.small_image_key_ = key;
+    g_presence.small_image_text_ = text;
+  }
+  g_dirty = true;
+}
+
+void Stop() {
+  if (!g_running.exchange(false))
+    return;
+  if (g_thread.joinable())
+    g_thread.join();
+}
+
+}  // namespace rex::discord_rpc

--- a/src/system/CMakeLists.txt
+++ b/src/system/CMakeLists.txt
@@ -83,7 +83,9 @@ if(REXGLUE_ENABLE_PERF_COUNTERS)
 endif()
 
 if(WIN32)
-    target_link_libraries(rexruntime PRIVATE ws2_32)
+  target_link_libraries(rexruntime PRIVATE rexdiscord ws2_32)
+elseif(LINUX)
+  target_link_libraries(rexruntime PRIVATE rexdiscord)
 endif()
 
 if(REXGLUE_USE_D3D12)


### PR DESCRIPTION
Built-in Discord Rich Presence support to rexglue via a lightweight, dependency free IPC client. This allows applications built on rexglue sdk to display realtime activity in Discord (details, state, images, timestamps) without pulling in the official Discord Game SDK or any thirdparty library.

- [X] Discord displays Rich Presence when a configured recomp is running and Discord is open
- [X] Toggling `discord_activity` via cvar toggles the activity without a restart
- [X] Worker thread reconnects automatically after Discord is restarted
- [X] `Stop()` and normal process exit clears the discord activity

# How to setup
- Head to the [Discord Applications Dashboard](https://discord.com/developers/applications) and create a application for your recomp

<img width="450" height="400" alt="image" src="https://github.com/user-attachments/assets/d6474b0d-f316-414b-920f-c7886bd987ac" />

- Optionally upload art assets

<img width="700" height="400" alt="image" src="https://github.com/user-attachments/assets/a63db0ef-bd81-4cf9-9909-7c031a03b908" />



- Inside your app header for me this is `retip_app.h` you will need to setup the discord rpc and start it inside OnPostSetup() if you want the discord activity to start as soon as the game starts. You will need to provide it the application id from the Discord Applications Dashboard step we did on step one.

``` cpp
#include <rex/discord_rpc.h>

void OnPostSetup() override {

    rex::discord_rpc::Presence rpc;

    rpc.details_ = "";
    rpc.state_ = "";
    rpc.large_image_key_ = "10979_viva_piata_trouble_in_paradise";
    rpc.large_image_text_ = "ReTiP";

    //rex::discord_rpc::Start(Application ID, Settings);
    rex::discord_rpc::Start("1497091207132876860", rpc);
}
```
<img width="567" height="579" alt="image" src="https://github.com/user-attachments/assets/bc1ff491-b85f-4002-9fdb-a64a4e936f54" />

- Finally inside a hook you can configure the RPC and pass in variables like I do in ReTiP when you switch maps
``` cpp
    rex::discord_rpc::SetDetails(std::string("In ") + ActualSceneName);
```

<img width="274" height="107" alt="image" src="https://github.com/user-attachments/assets/6e8da00a-5198-4e5d-9ec5-323dabedb312" />

Addresses issue: #339 