### PR TITLE
build: link rexruntime statically into rexglue

### DIFF
--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -118,7 +118,7 @@ target_include_directories(rexcodegen
 target_link_libraries(rexcodegen
     PUBLIC
         rexcore
-        rexruntime
+        rexruntime_static
         fmt::fmt
         spdlog::spdlog
     PRIVATE

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -64,6 +64,12 @@ set(REXKERNEL_SOURCES
 )
 
 list(TRANSFORM REXKERNEL_SOURCES PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
-target_sources(rexruntime PRIVATE ${REXKERNEL_SOURCES})
+target_sources(rexruntime_objects PRIVATE ${REXKERNEL_SOURCES})
 
-target_link_libraries(rexruntime PRIVATE o1heap rexcore rexfilesystem rexgraphics rexui rexaudio rexinput imgui)
+set(_rex_kernel_deps o1heap rexcore rexfilesystem rexgraphics rexui rexaudio rexinput imgui)
+# Object lib needs these for compile-time include dirs; shared and static each
+# link them directly because OBJECT libraries do not forward another OBJECT
+# library's compiled objects to their consumers.
+target_link_libraries(rexruntime_objects PRIVATE ${_rex_kernel_deps})
+target_link_libraries(rexruntime        PRIVATE ${_rex_kernel_deps})
+target_link_libraries(rexruntime_static PRIVATE ${_rex_kernel_deps})

--- a/src/system/CMakeLists.txt
+++ b/src/system/CMakeLists.txt
@@ -44,10 +44,58 @@ set(REXSYSTEM_SOURCES
     xex_module.cpp
 )
 
-add_library(rexruntime SHARED ${REXSYSTEM_SOURCES})
+# Compile system sources once. Kernel sources are appended in src/kernel/CMakeLists.txt.
+add_library(rexruntime_objects OBJECT ${REXSYSTEM_SOURCES})
+target_include_directories(rexruntime_objects PRIVATE
+    $<BUILD_INTERFACE:${REXGLUE_ROOT}/include>
+    ${REXGLUE_ROOT}/thirdparty
+)
+target_link_libraries(rexruntime_objects PRIVATE
+    simde
+    fmt::fmt
+    spdlog::spdlog
+    tomlplusplus
+    SDL3::SDL3
+    aes128
+    mspack
+)
+
+if(REXGLUE_ENABLE_TRACY)
+    target_link_libraries(rexruntime_objects PRIVATE TracyClient)
+    target_compile_definitions(rexruntime_objects PRIVATE
+        $<$<NOT:$<CONFIG:Release>>:REXGLUE_ENABLE_PROFILING>)
+endif()
+
+if(REXGLUE_ENABLE_PERF_COUNTERS)
+    target_compile_definitions(rexruntime_objects PRIVATE
+        $<$<NOT:$<CONFIG:Release>>:REXGLUE_ENABLE_PERF_COUNTERS>)
+endif()
+
+if(WIN32)
+    target_link_libraries(rexruntime_objects PRIVATE ws2_32)
+    target_compile_definitions(rexruntime_objects PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+endif()
+
+if(REXGLUE_USE_D3D12)
+    target_link_libraries(rexruntime_objects PRIVATE dxgi dxguid dxc-headers)
+    target_compile_definitions(rexruntime_objects PRIVATE REX_HAS_D3D12=1)
+endif()
+
+if(REXGLUE_USE_VULKAN)
+    target_link_libraries(rexruntime_objects PRIVATE
+        volk::volk
+        GPUOpen::VulkanMemoryAllocator
+        SPIRV-Tools-static
+    )
+    target_compile_definitions(rexruntime_objects PRIVATE REX_HAS_VULKAN=1)
+endif()
+
+# Shared variant: the public face for host applications
+add_library(rexruntime SHARED)
+target_link_libraries(rexruntime PRIVATE rexruntime_objects)
 add_library(rex::runtime ALIAS rexruntime)
-add_library(rex::system ALIAS rexruntime)
-add_library(rex::kernel ALIAS rexruntime)
+add_library(rex::system  ALIAS rexruntime)
+add_library(rex::kernel  ALIAS rexruntime)
 
 set_target_properties(rexruntime PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
@@ -91,6 +139,7 @@ if(REXGLUE_USE_D3D12)
     target_link_libraries(rexruntime PUBLIC dxgi dxguid dxc-headers)
     target_compile_definitions(rexruntime PUBLIC REX_HAS_D3D12=1)
 endif()
+
 if(REXGLUE_USE_VULKAN)
     target_link_libraries(rexruntime PUBLIC
         volk::volk
@@ -98,4 +147,37 @@ if(REXGLUE_USE_VULKAN)
         SPIRV-Tools-static
     )
     target_compile_definitions(rexruntime PUBLIC REX_HAS_VULKAN=1)
+endif()
+
+# Static variant: used only by rexcodegen/rexglue
+add_library(rexruntime_static STATIC)
+target_link_libraries(rexruntime_static PRIVATE
+    rexruntime_objects
+    simde
+    fmt::fmt
+    spdlog::spdlog
+    tomlplusplus
+    SDL3::SDL3
+    aes128
+    mspack
+)
+
+if(REXGLUE_ENABLE_TRACY)
+    target_link_libraries(rexruntime_static PRIVATE TracyClient)
+endif()
+
+if(WIN32)
+    target_link_libraries(rexruntime_static PRIVATE ws2_32)
+endif()
+
+if(REXGLUE_USE_D3D12)
+    target_link_libraries(rexruntime_static PRIVATE dxgi dxguid dxc-headers)
+endif()
+
+if(REXGLUE_USE_VULKAN)
+    target_link_libraries(rexruntime_static PRIVATE
+        volk::volk
+        GPUOpen::VulkanMemoryAllocator
+        SPIRV-Tools-static
+    )
 endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -34,7 +34,6 @@ target_include_directories(unit_tests PRIVATE
 target_link_libraries(unit_tests PRIVATE
     rexcore
     rexcodegen
-    rexruntime
     Catch2::Catch2WithMain
 )
 


### PR DESCRIPTION
Introduce rexruntime_objects (OBJECT library) compiled from the system + kernel sources, and rexruntime_static (STATIC) that absorbs it alongside all runtime deps. rexcodegen now links rexruntime_static instead of the shared library, so rexglue becomes a fully self-contained executable with no librexruntime.so dependency at runtime.

The shared rexruntime target and its public install/export interface are left unchanged, so host applications continue shipping the shared library exactly as before.

Removes the explicit rexruntime link from unit_tests to avoid mixing the shared and static copies of the runtime in the same executable (the runtime now arrives through rexcodegen -> rexruntime_static). ppc_tests is unchanged as it does not link rexcodegen.

Tested working on both Windows 11 and Arch Linux (CachyOS).

Fixes #347 and #348.