### PR TITLE
fix(codegen): make vaddsws use blendv_ps via casts in vaddsws

### DIFF
--- a/src/codegen/builders/vector.cpp
+++ b/src/codegen/builders/vector.cpp
@@ -277,8 +277,11 @@ bool build_vaddsws(BuilderContext& ctx) {
       "simde_mm_set1_epi32(0x7FFFFFFF));");
   // Blend: select sat_val where overflow MSB is set, else sum
   ctx.println(
-      "\t\tsimde_mm_store_si128((simde__m128i*){}.u8, simde_mm_blendv_epi8(sum, sat_val, "
-      "overflow));",
+      "\t\tsimde_mm_store_si128((simde__m128i*){}.u8, "
+      "simde_mm_castps_si128(simde_mm_blendv_ps("
+      "simde_mm_castsi128_ps(sum), "
+      "simde_mm_castsi128_ps(sat_val), "
+      "simde_mm_castsi128_ps(overflow))));",
       vD);
   ctx.println("\t}}");
   return true;


### PR DESCRIPTION
Before, `vaddsws` used `blendv_epi8`, so the overflow mask could accidentally select saturation bytes based on bits inside each 32-bit lane, corrupting results even when no signed word overflow occurred. After the change, the selection is done per 32-bit lane with `blendv_ps`, so each word either keeps the exact add result or is fully replaced with the correct signed saturation value.

Titles like Banjo Kazooei: Nuts & Bolts, KAMEO: Elements of Power, and Forza Horizon 1 all contained this instruction and resulted in models jittering/resizing themselves when they were not supposed to. The fixes suggested in commit `fix(codegen): make vaddsws use blendv_ps via casts in vaddsws` addresses these issues.

Solves #338 