### PR TITLE
fix(system): preserve heap state across DLL loads

### DIFF
--- a/src/system/xex_module.cpp
+++ b/src/system/xex_module.cpp
@@ -460,8 +460,6 @@ int XexModule::ReadImage(const void* xex_addr, size_t xex_length, bool use_dev_k
     return 0;
   }
 
-  memory()->LookupHeap(base_address_)->Reset();
-
   aes_decrypt_buffer(use_dev_key ? xe_xex2_devkit_key : xe_xex2_retail_key,
                      reinterpret_cast<const uint8_t*>(xex_security_info()->aes_key), 16,
                      session_key_, 16);


### PR DESCRIPTION
Tried running codegen on a title with a DLL and rex would get this error right at the end.
```
[error] [sys] BaseHeap::Release failed because address is not a region start
```

`XexModule::ReadImage()` resets the entire heap every time it loaded a non-patch XEX. Loading the DLL (address arround 0x88000000) seemed wiped the allocation metadata for the already-loaded entrypoint, so shutdown later tried to release Default.xex at 0x82000000 and reported that it was “not a region start.” The single tweak removes that whole-heap reset so each module preserves existing heap book keeping and relies on its own AllocFixed call to reserve its image range. This should work because multi-module loads no longer invalidate earlier modules’ allocations, so unload/shutdown can release each image using intact page table metadata. I am open to suggestions on any tweaks