### PR TITLE
Fix Vulkan texture exponent bias, depth-only pipeline stalls, and WaitMultiple polling overhead

### DIFF
--- a/src/core/threading_posix.cpp
+++ b/src/core/threading_posix.cpp
@@ -281,6 +281,14 @@ class PosixConditionBase {
                         ? std::chrono::steady_clock::time_point::max()
                         : start_time + timeout;
 
+    // The poll interval backs off exponentially (capped) the longer nothing
+    // is signaled, so a long idle wait doesn't keep re-locking every handle's
+    // mutex ~1000 times/sec (measured as a real CPU cost on waits across
+    // several handles, e.g. AudioSystem's per-client semaphore WaitAny).
+    // Freshly started/likely-to-resolve-soon waits still poll at 1ms.
+    auto poll_interval = std::chrono::milliseconds(1);
+    constexpr auto kMaxPollInterval = std::chrono::milliseconds(16);
+
     while (true) {
       size_t first_signaled = std::numeric_limits<size_t>::max();
       bool condition_met = false;
@@ -358,12 +366,13 @@ class PosixConditionBase {
       }
 
       if (timeout == std::chrono::milliseconds::max()) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        std::this_thread::sleep_for(poll_interval);
       } else {
         auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - now);
-        auto sleep_time = std::min(remaining, std::chrono::milliseconds(1));
+        auto sleep_time = std::min(remaining, poll_interval);
         std::this_thread::sleep_for(sleep_time);
       }
+      poll_interval = std::min(poll_interval * 2, kMaxPollInterval);
     }
   }
 

--- a/src/graphics/pipeline/shader/spirv_translator_fetch.cpp
+++ b/src/graphics/pipeline/shader/spirv_translator_fetch.cpp
@@ -1409,8 +1409,7 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
             builder_->createUnaryOp(spv::OpLogicalNot, type_bool_, is_all_signed);
 
         // Load the fetch constant word 4, needed unconditionally for LOD
-        // biasing, for result exponent biasing, and conditionally for stacked
-        // texture filtering.
+        // biasing and conditionally for stacked texture filtering.
         id_vector_temp_.clear();
         id_vector_temp_.push_back(const_int_0_);
         id_vector_temp_.push_back(
@@ -2030,10 +2029,22 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
         }
 
         // Apply the exponent bias from the bits 13:18 of the fetch constant
-        // word 4.
+        // word 3.
+        id_vector_temp_.clear();
+        id_vector_temp_.push_back(const_int_0_);
+        id_vector_temp_.push_back(
+            builder_->makeIntConstant(int((fetch_constant_word_0_index + 3) >> 2)));
+        id_vector_temp_.push_back(
+            builder_->makeIntConstant(int((fetch_constant_word_0_index + 3) & 3)));
+        spv::Id fetch_constant_word_3 = builder_->createLoad(
+            builder_->createAccessChain(spv::StorageClassUniform, uniform_fetch_constants_,
+                                        id_vector_temp_),
+            spv::NoPrecision);
+        spv::Id fetch_constant_word_3_signed =
+            builder_->createUnaryOp(spv::OpBitcast, type_int_, fetch_constant_word_3);
         spv::Id result_exponent_bias = builder_->createBinBuiltinCall(
             type_float_, ext_inst_glsl_std_450_, GLSLstd450Ldexp, const_float_1_,
-            builder_->createTriOp(spv::OpBitFieldSExtract, type_int_, fetch_constant_word_4_signed,
+            builder_->createTriOp(spv::OpBitFieldSExtract, type_int_, fetch_constant_word_3_signed,
                                   builder_->makeUintConstant(13), builder_->makeUintConstant(6)));
         {
           uint32_t result_remaining_components = used_result_nonzero_components;

--- a/src/graphics/vulkan/pipeline_cache.cpp
+++ b/src/graphics/vulkan/pipeline_cache.cpp
@@ -1111,8 +1111,8 @@ bool VulkanPipelineCache::ConfigurePipeline(
     }
   }
 
-  bool use_async = REXCVAR_GET(async_shader_compilation) && !creation_threads_.empty() &&
-                   pixel_shader && placeholder_pixel_shader_ != VK_NULL_HANDLE;
+  bool use_async = REXCVAR_GET(async_shader_compilation) && !creation_threads_.empty();
+  bool use_placeholder_swap = use_async && pixel_shader && placeholder_pixel_shader_ != VK_NULL_HANDLE;
   uint8_t async_priority = pipeline_util::kPriorityLowest;
   if (use_async) {
     uint32_t bound_rts =
@@ -1159,20 +1159,34 @@ bool VulkanPipelineCache::ConfigurePipeline(
   bool queued_async_creation = false;
   if (use_async) {
     creation_arguments_real.priority = async_priority;
-    PipelineCreationArguments creation_arguments_placeholder;
-    if (TryGetPipelineCreationArgumentsForDescription(description, &pipeline,
-                                                      creation_arguments_placeholder, true)) {
-      pipeline.second.is_placeholder.store(true, std::memory_order_release);
-      if (EnsurePipelineCreated(creation_arguments_placeholder, placeholder_pixel_shader_)) {
-        {
-          std::lock_guard<std::mutex> lock(creation_request_lock_);
-          creation_queue_.push(creation_arguments_real);
+    if (use_placeholder_swap) {
+      PipelineCreationArguments creation_arguments_placeholder;
+      if (TryGetPipelineCreationArgumentsForDescription(description, &pipeline,
+                                                        creation_arguments_placeholder, true)) {
+        pipeline.second.is_placeholder.store(true, std::memory_order_release);
+        if (EnsurePipelineCreated(creation_arguments_placeholder, placeholder_pixel_shader_)) {
+          {
+            std::lock_guard<std::mutex> lock(creation_request_lock_);
+            creation_queue_.push(creation_arguments_real);
+          }
+          creation_request_cond_.notify_one();
+          queued_async_creation = true;
+        } else {
+          pipeline.second.is_placeholder.store(false, std::memory_order_release);
         }
-        creation_request_cond_.notify_one();
-        queued_async_creation = true;
-      } else {
-        pipeline.second.is_placeholder.store(false, std::memory_order_release);
       }
+    } else {
+      // No pixel shader (e.g. depth/shadow-only pipelines): there is nothing
+      // cheaper to substitute while the real pipeline compiles on a
+      // background thread, so skip drawing with it for a few frames instead
+      // of blocking the render thread on synchronous compilation.
+      pipeline.second.is_placeholder.store(true, std::memory_order_release);
+      {
+        std::lock_guard<std::mutex> lock(creation_request_lock_);
+        creation_queue_.push(creation_arguments_real);
+      }
+      creation_request_cond_.notify_one();
+      queued_async_creation = true;
     }
   }
 


### PR DESCRIPTION
## Summary

Three independent fixes found while debugging visual corruption and stuttering under the Vulkan backend, running Lollipop: Chainsaw via the Re-Cherry mod loader (Linux, NVIDIA proprietary driver):

1. **`spirv_translator_fetch.cpp`** - the SPIR-V texture-fetch translator read fetch constant word 4 for the result exponent bias instead of word 3 (D3D12's DXBC translator already reads word 3 for this). Caused blown-out brightness on affected texture fetches, Vulkan-only.

2. **`vulkan/pipeline_cache.cpp`** - async pipeline compilation required a pixel shader, so depth/shadow-only pipelines (no pixel shader) always compiled synchronously on the render thread. These are created continuously during gameplay (not just at load) whenever the camera reveals new shadow casters, causing render-thread stalls. Extended the existing "skip this draw, retry next frame" placeholder mechanism to cover this case (there's nothing cheaper to substitute for a depth-only pipeline, so it just queues the real one on the background thread pool and skips drawing with it until ready).

3. **`core/threading_posix.cpp`** - `PosixConditionBase::WaitMultiple` (backing `KeWaitForMultipleObjects`-style waits) polled every handle via `pthread_mutex_trylock` on a fixed 1ms interval regardless of wait duration. Any guest thread waiting on several kernel objects at once pays this cost continuously - measured via `perf`+Tracy on `AudioSystem`'s worker thread (waits on 9 handles), which dropped from ~68% to ~21% CPU after adding exponential backoff (1ms -> 16ms cap, resets per wait). Semantics/timeouts unchanged, only the poll interval.

## Test plan

- [x] Rebuilt RelWithDebInfo, confirmed no new warnings from the changed files
- [x] Ran Lollipop: Chainsaw via Re-Cherry on Linux/NVIDIA for multiple sessions after each fix
- [x] Fix 1: confirmed visually via screenshot that the exponent-bias corruption was gone
- [x] Fix 2: confirmed via log analysis that ~50% of newly created pipelines in a real session have no pixel shader; no crashes/hangs across repeated sessions after the change
- [x] Fix 3: confirmed via `perf record`/`perf report` before and after (WaitMultiple self-time 6.43% -> 2.73%, `pthread_mutex_trylock` 5.13% -> 2.30%) and `ps -T` thread CPU (Audio Worker 68% -> 21%); no hangs or audio glitches observed
- [ ] Not tested on D3D12/Windows or non-NVIDIA GPUs - would appreciate a sanity check there, especially for fix 3 since it's used well beyond the audio path