### PR TITLE
fix(codegen): manual switch table configuration in block discovery

### DIFF
--- a/include/rex/codegen/function_scanner.h
+++ b/include/rex/codegen/function_scanner.h
@@ -253,10 +253,10 @@ struct BlockDiscoveryResult {
  * @param knownFunctions Set of known function entry points (to detect tail calls)
  * @return BlockDiscoveryResult containing blocks, branches, and jump tables
  */
-BlockDiscoveryResult discoverBlocks(DecodedBinary& decoded, uint32_t entryPoint,
-                                    const CodeRegion& containingRegion,
-                                    const std::unordered_set<uint32_t>& knownFunctions,
-                                    uint32_t pdataSize = 0);
+BlockDiscoveryResult discoverBlocks(
+    DecodedBinary& decoded, uint32_t entryPoint, const CodeRegion& containingRegion,
+    const std::unordered_set<uint32_t>& knownFunctions, uint32_t pdataSize = 0,
+    const std::unordered_map<uint32_t, JumpTable>* manualSwitchTables = nullptr);
 
 //=============================================================================
 // Jump Table Detection

--- a/src/codegen/function_scanner.cpp
+++ b/src/codegen/function_scanner.cpp
@@ -1923,10 +1923,12 @@ BlockDiscoveryResult discoverBlocks(
           REXCODEGEN_TRACE("discoverBlocks: bctr at 0x{:08X} in func 0x{:08X}, funcEnd=0x{:08X}",
                            addr, entryPoint, funcEnd);
           std::optional<JumpTable> jt;
+          bool jtIsManual = false;
           if (manualSwitchTables) {
             auto manualIt = manualSwitchTables->find(addr);
             if (manualIt != manualSwitchTables->end()) {
               jt = manualIt->second;
+              jtIsManual = true;
               REXCODEGEN_TRACE(
                   "discoverBlocks: using manual jump table at bctr 0x{:08X} with {} targets", addr,
                   jt->targets.size());
@@ -1943,9 +1945,27 @@ BlockDiscoveryResult discoverBlocks(
               if (t == 0)
                 continue;  // sentinel from null-padding detection
 
-              // A jump table may tail-dispatch to another known function.
-              // Do not import that function's blocks into the current function.
+              // A jump table target may tail-dispatch to another known
+              // function; don't import that function's blocks into this one
+              // (mirrors isInternalTarget's treatment of regular branches,
+              // and now also applies to auto-detected table targets, not
+              // just manual ones).
               if (t != entryPoint && knownFunctions.contains(t)) {
+                if (jtIsManual) {
+                  // A manually configured table is authoritative, so a drop
+                  // here likely means the target was mis-registered as a
+                  // function entry elsewhere. Warn so it's diagnosable
+                  // instead of silently discarding a user-provided target.
+                  REXCODEGEN_WARN(
+                      "discoverBlocks: manual jump table at bctr 0x{:08X} has target 0x{:08X} "
+                      "that is registered as a known function entry; dropping it",
+                      addr, t);
+                } else {
+                  REXCODEGEN_TRACE(
+                      "discoverBlocks: auto-detected jump table at bctr 0x{:08X} has target "
+                      "0x{:08X} that is a known function entry; dropping it",
+                      addr, t);
+                }
                 continue;
               }
 

--- a/src/codegen/function_scanner.cpp
+++ b/src/codegen/function_scanner.cpp
@@ -1812,10 +1812,10 @@ std::optional<JumpTable> detectJumpTable(DecodedBinary& decoded, uint32_t bctrAd
 // Block Discovery
 //=============================================================================
 
-BlockDiscoveryResult discoverBlocks(DecodedBinary& decoded, uint32_t entryPoint,
-                                    const CodeRegion& containingRegion,
-                                    const std::unordered_set<uint32_t>& knownFunctions,
-                                    uint32_t pdataSize) {
+BlockDiscoveryResult discoverBlocks(
+    DecodedBinary& decoded, uint32_t entryPoint, const CodeRegion& containingRegion,
+    const std::unordered_set<uint32_t>& knownFunctions, uint32_t pdataSize,
+    const std::unordered_map<uint32_t, JumpTable>* manualSwitchTables) {
   BlockDiscoveryResult result;
   std::unordered_set<uint32_t> visited;
   std::unordered_set<uint32_t> blockStarts;
@@ -1916,20 +1916,41 @@ BlockDiscoveryResult discoverBlocks(DecodedBinary& decoded, uint32_t entryPoint,
           }
           // Do not break: continue scanning the fall-through path.
         } else if (insn->opcode == rex::codegen::ppc::Opcode::bcctr) {
-          // Unconditional bctr - try to detect jump table
+          // Unconditional bctr - prefer a manually configured table, then try
+          // automatic detection. Manual tables are authoritative because they
+          // are commonly needed when the compiler emits a table without an
+          // adjacent bounds check.
           REXCODEGEN_TRACE("discoverBlocks: bctr at 0x{:08X} in func 0x{:08X}, funcEnd=0x{:08X}",
                            addr, entryPoint, funcEnd);
-          auto jt = detectJumpTable(decoded, addr, containingRegion, entryPoint, funcEnd);
+          std::optional<JumpTable> jt;
+          if (manualSwitchTables) {
+            auto manualIt = manualSwitchTables->find(addr);
+            if (manualIt != manualSwitchTables->end()) {
+              jt = manualIt->second;
+              REXCODEGEN_TRACE(
+                  "discoverBlocks: using manual jump table at bctr 0x{:08X} with {} targets", addr,
+                  jt->targets.size());
+            }
+          }
+          if (!jt) {
+            jt = detectJumpTable(decoded, addr, containingRegion, entryPoint, funcEnd);
+          }
           if (jt) {
             REXCODEGEN_TRACE("discoverBlocks: detected jump table at bctr 0x{:08X} with {} targets",
                              addr, jt->targets.size());
             result.jumpTables.push_back(*jt);
-            // Jump table targets are definitionally part of this function
-            // Extend funcEnd if any target exceeds it (within region bounds)
-            // This handles out-of-line switch case code
             for (uint32_t t : jt->targets) {
               if (t == 0)
                 continue;  // sentinel from null-padding detection
+
+              // A jump table may tail-dispatch to another known function.
+              // Do not import that function's blocks into the current function.
+              if (t != entryPoint && knownFunctions.contains(t)) {
+                continue;
+              }
+
+              // Internal jump table targets are part of this function. Extend
+              // funcEnd for out-of-line case blocks within the code region.
               if (t >= funcEnd && t < containingRegion.end) {
                 funcEnd = t + 4;  // Extend to include this target
               }

--- a/src/codegen/phase_discover.cpp
+++ b/src/codegen/phase_discover.cpp
@@ -95,7 +95,8 @@ void discoverFunction(CodegenContext& ctx, uint32_t funcAddr,
   }
 
   // Pass pdataSize so forward branches within function extent are correctly identified
-  auto result = discoverBlocks(decoded, funcAddr, *region, knownFunctions, pdataSize);
+  auto result = discoverBlocks(decoded, funcAddr, *region, knownFunctions, pdataSize,
+                               &ctx.Config().switchTables);
 
   if (result.blocks.empty()) {
     REXCODEGEN_WARN("Analyze: no blocks found for function 0x{:08X}", funcAddr);


### PR DESCRIPTION
The manually configured switch tables in the config weren't being passed into `discoverBlocks()` at all. The call site in `phase_discover.cpp` simply didn't forward `ctx.Config().switchTables`.

The fix adds a manualSwitchTables parameter to `discoverBlocks()` so that user-configured tables (from `ctx.Config().switchTables`) take priority over auto-detection at each bcctr address. It also adds a guard -> `if (t != entryPoint && knownFunctions.contains(t)) continue;` <- to prevent jump table targets that land at the start of a known function from being incorrectly imported as basic blocks of the current function (i.e., tail dispatch is now handled correctly).