### PR TITLE
Handle XPresenceInitialize in XLIVEBASE dispatch

### DIFF
--- a/src/kernel/xam/apps/xlivebase_app.cpp
+++ b/src/kernel/xam/apps/xlivebase_app.cpp
@@ -73,6 +73,10 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message, uint32_t buffer_pt
       REXKRNL_DEBUG("XLiveBaseUnk58046({:08X}, {:08X}) unimplemented", buffer_ptr, buffer_length);
       return X_E_SUCCESS;
     }
+    case 0x00058037: {
+      REXKRNL_DEBUG("XPresenceInitialize({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return X_E_SUCCESS;
+    }
   }
   REXKRNL_ERROR(
       "Unimplemented XLIVEBASE message app={:08X}, msg={:08X}, arg1={:08X}, "


### PR DESCRIPTION
XLIVEBASE message 0x00058037 (XPresenceInitialize) had no case in XLiveBaseApp::DispatchMessageSync, so it fell through to the unimplemented-message path and returned failure (X_E_FAIL).

Some titles (Forza Motorsport 2 in my case) gate accepting a signed-in profile at the press-start/menu flow on this call succeeding. Without it, the game can get stuck repeatedly showing a "no profile signed in" prompt.