### PR TITLE
Byte-swap message box title/body text

### DIFF
--- a/src/kernel/xam/xam_ui.cpp
+++ b/src/kernel/xam/xam_ui.cpp
@@ -276,10 +276,15 @@ u32 XamShowMessageBoxUI_entry(u32 user_index, mapped_wstring title_ptr, mapped_w
       result_ptr.guest_address(), overlapped.guest_address());
   std::string title;
   if (title_ptr) {
-    title = rex::string::to_utf8(title_ptr.value());
+    title = rex::string::to_utf8(rex::memory::load_and_swap<std::u16string>(
+        REX_KERNEL_MEMORY()->TranslateVirtual(title_ptr.guest_address())));
   } else {
     title = "";  // TODO(gibbed): default title based on flags?
   }
+  std::string text_str =
+      text_ptr ? rex::string::to_utf8(rex::memory::load_and_swap<std::u16string>(
+                     REX_KERNEL_MEMORY()->TranslateVirtual(text_ptr.guest_address())))
+               : "";
 
   std::vector<std::string> buttons;
   for (uint32_t i = 0; i < button_count; ++i) {
@@ -321,8 +326,7 @@ u32 XamShowMessageBoxUI_entry(u32 user_index, mapped_wstring title_ptr, mapped_w
     ui::ImGuiDrawer* imgui_drawer = emulator->imgui_drawer();
     if (imgui_drawer) {
       result = xeXamDispatchDialog<MessageBoxDialog>(
-          new MessageBoxDialog(imgui_drawer, title, rex::string::to_utf8(text_ptr.value()), buttons,
-                               active_button),
+          new MessageBoxDialog(imgui_drawer, title, text_str, buttons, active_button),
           close, overlapped.guest_address());
     } else {
       // Fallback to headless if no drawer available

--- a/src/kernel/xam/xam_ui.cpp
+++ b/src/kernel/xam/xam_ui.cpp
@@ -281,10 +281,10 @@ u32 XamShowMessageBoxUI_entry(u32 user_index, mapped_wstring title_ptr, mapped_w
   } else {
     title = "";  // TODO(gibbed): default title based on flags?
   }
-  std::string text_str =
-      text_ptr ? rex::string::to_utf8(rex::memory::load_and_swap<std::u16string>(
-                     REX_KERNEL_MEMORY()->TranslateVirtual(text_ptr.guest_address())))
-               : "";
+  std::string text_str = text_ptr
+                             ? rex::string::to_utf8(rex::memory::load_and_swap<std::u16string>(
+                                   REX_KERNEL_MEMORY()->TranslateVirtual(text_ptr.guest_address())))
+                             : "";
 
   std::vector<std::string> buttons;
   for (uint32_t i = 0; i < button_count; ++i) {
@@ -326,8 +326,8 @@ u32 XamShowMessageBoxUI_entry(u32 user_index, mapped_wstring title_ptr, mapped_w
     ui::ImGuiDrawer* imgui_drawer = emulator->imgui_drawer();
     if (imgui_drawer) {
       result = xeXamDispatchDialog<MessageBoxDialog>(
-          new MessageBoxDialog(imgui_drawer, title, text_str, buttons, active_button),
-          close, overlapped.guest_address());
+          new MessageBoxDialog(imgui_drawer, title, text_str, buttons, active_button), close,
+          overlapped.guest_address());
     } else {
       // Fallback to headless if no drawer available
       auto run = [result_ptr, active_button]() -> X_RESULT {


### PR DESCRIPTION
XamShowMessageBoxUI_entry decoded the dialog's title and body via mapped_wstring::value(), which builds a u16string_view directly from host memory with no endianness conversion. Guest (Xbox 360) UTF-16 strings are big-endian; the host is little-endian x64, so every 16-bit code unit came out byte-swapped. Button labels were already decoded correctly a few lines below, via rex::memory::load_and_swap<std::u16string>(...) — only title/body used the wrong path.