### PR TITLE
vmsum qnan spec-correctness fix

### DIFF
--- a/include/rex/ppc/context.h
+++ b/include/rex/ppc/context.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <bit>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 
@@ -235,6 +236,57 @@ struct FPSCRRegister {
     setcsr(csr);
   }
 };
+
+// Xenon vmsum3fp128/vmsum4fp128 return QNaN when the single-precision dot
+// product overflows, not +/-inf. simde_mm_dp_ps gets this wrong: it computes in
+// single precision and saturates. The distinction is observable because it
+// flips comparisons -- inf is ordered against finite values, QNaN is not.
+//
+// Products of two floats are exact in double, so the only rounding is in the
+// accumulation and the final narrowing.
+inline float dotProductToGuestFloat(double acc) noexcept {
+  // Narrow first, then detect real overflow: a finite input that became
+  // infinite. Testing acc against FLT_MAX directly is wrong -- under
+  // round-to-nearest, doubles up to FLT_MAX + 2^103 narrow back to FLT_MAX
+  // without overflowing. Infinite inputs pass through; NaN propagates quieted.
+  const float result = static_cast<float>(acc);
+  if (std::isinf(result) && !std::isinf(acc)) {
+    return std::bit_cast<float>(uint32_t(0x7FC00000));
+  }
+  // Denormal outputs are flushed; the scalar path does not inherit the host FTZ
+  // mode the dp_ps path relied on.
+  if (result != 0.0f && (std::bit_cast<uint32_t>(result) & 0x7F800000u) == 0u) {
+    return std::bit_cast<float>(std::bit_cast<uint32_t>(result) & 0x80000000u);
+  }
+  return result;
+}
+
+// Guest elements are reversed relative to host lanes, so guest x,y,z are host
+// lanes 3,2,1 and w (lane 0) is excluded. Addition is not associative and the
+// order is observable under cancellation, so match Xenia's reduction: (x+z)+y.
+inline simde__m128 vmsum3fp(simde__m128 a, simde__m128 b) noexcept {
+  alignas(16) float av[4], bv[4];
+  simde_mm_store_ps(av, a);
+  simde_mm_store_ps(bv, b);
+  const double x = static_cast<double>(av[3]) * static_cast<double>(bv[3]);
+  const double y = static_cast<double>(av[2]) * static_cast<double>(bv[2]);
+  const double z = static_cast<double>(av[1]) * static_cast<double>(bv[1]);
+  return simde_mm_set1_ps(dotProductToGuestFloat((x + z) + y));
+}
+
+// As vmsum3fp, but all four elements participate: guest x,y,z,w are host lanes
+// 3,2,1,0. Xenia reduces this one pairwise -- (x+z)+(y+w) -- rather than
+// extending the 3-element chain, so match that.
+inline simde__m128 vmsum4fp(simde__m128 a, simde__m128 b) noexcept {
+  alignas(16) float av[4], bv[4];
+  simde_mm_store_ps(av, a);
+  simde_mm_store_ps(bv, b);
+  const double x = static_cast<double>(av[3]) * static_cast<double>(bv[3]);
+  const double y = static_cast<double>(av[2]) * static_cast<double>(bv[2]);
+  const double z = static_cast<double>(av[1]) * static_cast<double>(bv[1]);
+  const double w = static_cast<double>(av[0]) * static_cast<double>(bv[0]);
+  return simde_mm_set1_ps(dotProductToGuestFloat((x + z) + (y + w)));
+}
 
 }  // namespace rex::ppc
 

--- a/src/codegen/builders/vector.cpp
+++ b/src/codegen/builders/vector.cpp
@@ -184,22 +184,24 @@ bool build_vlogefp(BuilderContext& ctx) {
 //=============================================================================
 
 bool build_vmsum3fp128(BuilderContext& ctx) {
-  // 3-element dot product accounting for guest->host vector element reversal
-  // 0xEF = dot(yzw) with result broadcast to all elements (see constants doc)
+  // 3-element dot product accounting for guest->host vector element reversal.
+  // Not simde_mm_dp_ps: that saturates to +/-inf on overflow, where Xenon
+  // returns QNaN. See rex::ppc::vmsum3fp.
   ctx.emit_set_flush_mode(true);
   ctx.println(
-      "\tsimde_mm_store_ps({}.f32, simde_mm_dp_ps(simde_mm_load_ps({}.f32), "
-      "simde_mm_load_ps({}.f32), 0xEF));",
+      "\tsimde_mm_store_ps({}.f32, rex::ppc::vmsum3fp(simde_mm_load_ps({}.f32), "
+      "simde_mm_load_ps({}.f32)));",
       ctx.v(ctx.insn.operands[0]), ctx.v(ctx.insn.operands[1]), ctx.v(ctx.insn.operands[2]));
   return true;
 }
 
 bool build_vmsum4fp128(BuilderContext& ctx) {
-  // 4-element dot product: 0xFF = all 4 elements, result to all (see constants doc)
+  // 4-element dot product. Not simde_mm_dp_ps: that saturates to +/-inf on
+  // overflow, where Xenon returns QNaN. See rex::ppc::vmsum4fp.
   ctx.emit_set_flush_mode(true);
   ctx.println(
-      "\tsimde_mm_store_ps({}.f32, simde_mm_dp_ps(simde_mm_load_ps({}.f32), "
-      "simde_mm_load_ps({}.f32), 0xFF));",
+      "\tsimde_mm_store_ps({}.f32, rex::ppc::vmsum4fp(simde_mm_load_ps({}.f32), "
+      "simde_mm_load_ps({}.f32)));",
       ctx.v(ctx.insn.operands[0]), ctx.v(ctx.insn.operands[1]), ctx.v(ctx.insn.operands[2]));
   return true;
 }


### PR DESCRIPTION
fix(codegen): vmsum3fp128/vmsum4fp128 return QNaN on overflow, not inf

before this change we lower both to simde_mm_dp_ps, which computes in single precision and saturates to +/-inf when the dot product overflows. On Xenon these instructions return QNaN when normal doubles instead.

Repro: a vector whose components are +/-FLT_MAX.

    dir = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX }

    simde_mm_dp_ps(dir, dir, 0xEF)  ->  +inf (calculated in single, cannot tell if we got garbage infs in or calculated normally, 3fp/4fp do that)
    hardware                        ->  QNaN (0x7FC00000) (correctly emitting we didnt get garbage infs in but our result cant fit in a single float)

dp_ps accumulates in single precision, so it rounds at every add; 3fp/4fp rounds exactly twice, once in the accumulation and once in the final narrowing, improving accuracy (side effect). guest code using these instructions for collision or distance maths gets a more faithful result as well as the right overflow behaviour.

GJK termination tests commonly seed a FLT_MAX previous-distance term (before this change, to dp_ps) as an infinity sentinel and compare it against a newly computed squared distance. on VMX that squared distance comes from vmsum3fp128, and the seeding iteration overflows the single precision output. any guest code shaped that way depends on the overflow producing an unordered result when normal finite floats where input, and takes the wrong branch when we hand back an ordered +/-inf, in GJK's case terminating the solver immediately and discarding any collision it would have found.

3fp/4fp inputs are floats, so the largest possible product is FLT_MAX^2 ~ 1.2e77 and a four-term sum tops out near 4.6e77, against a double's 1.8e308 ceiling. the accumulator/3fp/4fp can't overflow when given normal input. an infinite accumulator therefore means an infinite input, and those pass through untouched. everything else narrows to float, and QNaN is substituted exactly when 3fp/4fp recieved finite floats and emitted a finite double that can't fit in a single. +/-inf is emitted only when one of the inputs was a inf, relaying garbage in > out. previouisly, dp_ps would emit +/-inf regardless of if it got inf in, or 2 normal single floats, since it only accumulated in single and couldnt tell.

addition is not associative and the order is observable under cancellation, so the reduction matches Xenia's: (x + z) + y for the 3-element form and (x + z) + (y + w) for the 4-element one. denormal results are flushed by hand, since the scalar path no longer inherits the host FTZ mode that the dp_ps lowering relied on.

Xenia implements this behavior on purpose. double accumulation plus an MXCSR overflow check that substitutes QNaN (x64_sequences.cc, DOT_PRODUCT_3_V128 and DOT_PRODUCT_4_V128), commented "this implementation is accurate, it matches the results of xb360 vmsum3", and enabled by default (use_fast_dot_product defaults to false). xenia also comments its own result is "often off by 1 bit" from hardware, so matching Xenia only. VMX128 semantics are not documented anywhere ive found. the free60 encoding list gives the bit layout and nothing about rounding, NaN or overflow, if someone has hardware or documentation to confirm or refute this, that is worth more than anything here.

The symptom that led here: Forza Horizon 1 has no collision between cars or props, which pass through each other, while terrain and world borders collide fine. the convex-v-convex narrowphase is the only path using GJK, and CGJK::Intersecting never returns true for any caller. its termination predicate computes

    cur  = vmsum3fp128(dir, dir)
    prev = previous distance squared, seeded to FLT_MAX
    terminate if (FLT_EPSILON * prev) >= (prev - cur)

and CSimplex seeds dir to -FLT_MAX so that the first dot product overflows by design. With QNaN the compare is unordered, all lanes are false, and the seeding iteration falls through so the solver runs. With +inf it becomes 4.06e31 >= -inf, which is true, so the predicate terminates on iteration 1 of every call and GJK never reports a hit.

verified against a Xenia build, at the predicate's blr it returns 0, both cr6-derived term results are zero, and the stored distance reads 0x7FC00000. this change reproduces those measured values (0x7FC00000 for the sentinel, 0x4009B8E9 for a real search direction) where dp_ps gave +inf, and restores collision.