### PR TITLE
fix(ppc): keep host FP exceptions masked in FPSCRRegister::setcsr

### DIFF
--- a/include/rex/ppc/context.h
+++ b/include/rex/ppc/context.h
@@ -192,7 +192,18 @@ struct FPSCRRegister {
   static constexpr size_t FlushMask = Platform::FlushMask;
 
   inline uint32_t getcsr() noexcept { return Platform::getcsr(); }
-  inline void setcsr(uint32_t csr) noexcept { Platform::setcsr(csr); }
+  inline void setcsr(uint32_t csr) noexcept {
+    // Keep host FP exceptions masked on every write, not just in InitHost.
+    // Recompiled guest code reaches setcsr via storeFromGuest /
+    // enableFlushMode / etc., and a csr value that still has the exception
+    // bits in their trapping state (e.g. a context whose fpscr.csr field was
+    // zero-initialized before InitHost ran) would otherwise re-arm host FP
+    // traps and raise SIGFPE on the next FP op. InitHostExceptions applies the
+    // per-arch polarity (x86: 1 = masked, ARM: 1 = trap enabled), so it is used
+    // here rather than open-coding a mask that is correct on only one of them.
+    Platform::InitHostExceptions(csr);
+    Platform::setcsr(csr);
+  }
 
   inline uint32_t loadFromHost() noexcept {
     csr = getcsr();


### PR DESCRIPTION
Fixes #381.

> **Corrected.** An earlier version of this description claimed this bug surfaces as SIGFPE on Tegra X1 and Adreno hosts. I measured it and that is wrong — see [the correction on #381](https://github.com/rexglue/rexglue-sdk/issues/381#issuecomment-5034112409). Neither of those platforms implements FPCR trapping. The change below still stands, but as hardening for hosts that do, not as a fix for an observed crash on those two.

## Summary

`FPSCRRegister::InitHost()` masks the host FP exception traps once at context init, but every later write to the control word goes through `setcsr()`, which passed its argument straight to `Platform::setcsr()`. A csr value reaching `setcsr()` with the exception bits in their trapping state therefore re-arms host FP traps for the rest of that context's life — reachable via `storeFromGuest()` / `enableFlushMode()` / `enableFlushModeUnconditional()`.

This routes `setcsr()` through `Platform::InitHostExceptions()`, the helper `InitHost()` already uses, instead of open-coding a mask that is correct on only one arch.

## The asymmetry

The two `FPSCRPlatform` specialisations in `include/rex/platform/fpscr.h` give the same field opposite meanings:

| | `ExceptionMask` bits | Default state |
|---|---|---|
| x86_64 | **mask** bits, `1 = masked` | MXCSR default has all six set |
| aarch64 | **enable** bits, `1 = trap enabled` | FPCR default has them clear |

`InitHostExceptions()` already handles this (`\|=` on x86, `&= ~` on ARM). `setcsr()` just did not use it.

## Scope — measured, not assumed

Trapped FP exceptions are **optional** in ARMv8-A; where unimplemented the FPCR enable bits are RAZ/WI. Setting `FPCR.IOE|DZE` and executing `0.0/0.0`:

| Host | CPU | Bits stick? | Result |
|---|---|---|---|
| Switch, L4T 4.9.140 | Tegra X1, Cortex-A57 | No — RAZ/WI | NaN, no signal |
| Pocket DS, Fedora 44 | SM8550, Cortex-X3/A715 | No — RAZ/WI | NaN, no signal |
| Apple M4, Fedora aarch64 | Apple M4 | Yes — `0x300` | **SIGFPE** |
| Apple M4, macOS | Apple M4 | Yes — `0x300` | **SIGILL** |

So this matters on hosts implementing the optional trapping behaviour (Apple Silicon today, where on macOS it presents as SIGILL rather than SIGFPE). On the ARM cores I can test it is a **latent hazard, not an observed bug** — nothing currently writes the enable bits, since `storeFromGuest()` only touches the rounding field. On x86_64 it is a no-op: the MXCSR mask bits are already set.

Cost: one ALU op per `setcsr()`.

## Test plan

- [x] Builds clean; header syntax-checks standalone with `clang++ -std=c++23 -fsyntax-only` on x86_64 and aarch64.
- [x] FPCR trapping behaviour characterised on four hosts (table above).
- [ ] Pocket DS (aarch64): confirm no regression in rounding-mode / flush-to-zero behaviour — guest still controls RMode/FZ, only the trap-enable bits are forced.
- [ ] linux-amd64: confirm no behavioural change.

If you consider hardening against a currently-latent issue out of scope, that's a fair call — happy for this to be closed.

## Notes

First of the changes from the closed #346, resubmitted one issue at a time as requested. The rest will follow as separate issues + PRs once this has been looked at.
