### PR TITLE
fix(ui): load config before reading the path cvars it can set

### DIFF
--- a/src/ui/rex_app.cpp
+++ b/src/ui/rex_app.cpp
@@ -104,6 +104,10 @@ bool ReXApp::OnInitialize() {
 bool ReXApp::SetupEnvironment() {
   auto exe_dir = rex::filesystem::GetExecutableFolder();
 
+  auto default_config_path = exe_dir / (std::string(GetName()) + ".toml");
+  if (std::filesystem::exists(default_config_path))
+    rex::cvar::LoadConfig(default_config_path);
+
   std::filesystem::path game_dir;
   std::string game_data_cvar = REXCVAR_GET(game_data_root);
   if (!game_data_cvar.empty()) {
@@ -142,7 +146,7 @@ bool ReXApp::SetupEnvironment() {
   }
 
   PathConfig path_config{game_dir,  user_dir,     update_dir,
-                         cache_dir, metadata_dir, exe_dir / (std::string(GetName()) + ".toml")};
+                         cache_dir, metadata_dir, default_config_path};
   OnConfigurePaths(path_config);
   game_data_root_ = path_config.game_data_root;
   user_data_root_ = path_config.user_data_root;
@@ -152,8 +156,7 @@ bool ReXApp::SetupEnvironment() {
   config_path_ = path_config.config_path;
   resolved_defaults_ = std::move(path_config);
 
-  // Load config FIRST so log cvars have final values
-  if (std::filesystem::exists(config_path_))
+  if (config_path_ != default_config_path && std::filesystem::exists(config_path_))
     rex::cvar::LoadConfig(config_path_);
 
   // Late-phase logging


### PR DESCRIPTION
Fixes #383.

## Summary

`ReXApp::SetupEnvironment()` read the four path cvars (`game_data_root`, `user_data_root`, `update_data_root`, `cache_path`) and baked them into `PathConfig` before `rex::cvar::LoadConfig()` ran, so a value set in the TOML could never influence path resolution — the cvar still held its empty default at the moment it was read.

This resolves the default config path up front and loads it before those reads.

## Why this is safe

The default config path is `exe_dir / (GetName() + ".toml")` — derived purely from the executable folder and the app name, with no dependency on any cvar. So loading it first cannot become circular, which is presumably why it was placed later in the first place.

`OnConfigurePaths()` may still redirect `config_path`, so the existing load is kept for exactly that case, now guarded on the path having actually changed to avoid applying the same file twice.

## Ordering, before and after

| | before | after |
|---|---|---|
| resolve default config path | line 111 (inside `PathConfig`) | up front, line 79 |
| **load config** | **line 123** | **line 83** |
| read `game_data_root` etc. | lines 81-104 | after the load |
| load redirected config | — | only if `OnConfigurePaths` changed it |

The comment that was on line 121 (`// Load config FIRST so log cvars have final values`) was accurate for the logging setup below it, but the call sat under every path cvar read — so "FIRST" only held relative to logging.

## Test plan

- [x] Builds clean at v0.8.0 + this patch.
- [x] Ordering verified by reading `e8ce24f`; the bug is platform-independent (no arch-specific behaviour involved).
- [ ] Confirm `game_data_root` set in the TOML is now honoured with no command-line argument.
- [ ] Confirm passing `--game_data_root` on the command line still wins where both are present, and that a config redirected by `OnConfigurePaths` still applies.

## Notes

Independent of the aarch64 work in #381/#382 — this one reproduces anywhere, no special hardware needed. Submitted as its own issue + PR per the one-at-a-time request.
