### PR TITLE
fix(core/threading): arm suspend_count_ with the started state to close a lost-wakeup race

### DIFF
--- a/src/core/threading_posix.cpp
+++ b/src/core/threading_posix.cpp
@@ -1312,12 +1312,19 @@ void* PosixCondition<Thread>::ThreadStartRoutine(void* parameter) {
   {
     std::unique_lock<std::mutex> lock(thread->handle_.state_mutex_);
     thread->handle_.state_ = create_suspended ? State::kSuspended : State::kRunning;
+    // Arm the suspend counter in the SAME critical section that publishes the
+    // started state. Resume() only waits for state_ != kUninitialized, so if it
+    // observed the state published here while suspend_count_ was still 0 it
+    // would take the "not suspended" path, return false without decrementing,
+    // and the wait below would then never be satisfied.
+    if (create_suspended) {
+      thread->handle_.suspend_count_ = 1;
+    }
     thread->handle_.state_signal_.notify_all();
   }
 
   if (create_suspended) {
     std::unique_lock<std::mutex> lock(thread->handle_.state_mutex_);
-    thread->handle_.suspend_count_ = 1;
     thread->handle_.state_signal_.wait(lock,
                                        [thread] { return thread->handle_.suspend_count_ == 0; });
   }


### PR DESCRIPTION
Fixes #386.

## Summary

`ThreadStartRoutine` published the started state and armed the suspend counter in two separate critical sections, so a `Resume()` landing between them was lost and the thread waited forever.

```cpp
{ lock; state_ = create_suspended ? kSuspended : kRunning; notify_all(); }      // publishes "started"
if (create_suspended) { lock; suspend_count_ = 1; wait(suspend_count_ == 0); }  // arms only now
```

`Resume()` waits on `state_ != kUninitialized`, which the first block already satisfies, then returns early when `suspend_count_ == 0` — its constructor value — **without decrementing**. The child then sets `suspend_count_ = 1` and waits on a condition nothing will ever satisfy.

This moves `suspend_count_ = 1` into the same critical section that publishes `kSuspended`, making the two observations atomic with respect to `Resume()`.

## Why this is the minimal correct fix

A `Resume()` arriving **before** the thread starts still blocks in `WaitStarted()` — unchanged. One arriving **after** now always observes `suspend_count_ == 1`, decrements it, sets `kRunning` and signals; the child's wait predicate is then already true, so it does not block. The window no longer exists, because there is no longer a state in which the thread is observably started but not yet armed.

The second critical section is kept for the wait itself, since the child must release the lock to sleep.

## Verification

Clean single-instance run on stock linux-amd64, both binaries built in the same session from the same toolchain and differing only in this file, launches interleaved, `taskset -c 0-3`, 20 s each:

| Variant | Launches that lost a guest thread | Sample size |
|---|---|---|
| **unpatched** | **19** | 20 |
| **patched** | **0** | 20 |

Fisher exact two-sided **p = 3.0e-10**. Unpatched losses: `GPU VSync` ×15, `GPU Commands` ×3, both ×1 — the `GPU Commands` cases are the hard hangs.

**Stated limit:** 0/20 does not prove the residual rate is zero. By the rule of three the 95% upper bound on the patched failure rate is ~15%, so this decisively excludes anything near the ~95% baseline but would not detect a rarer, narrower window. Treat it as evidence of a large effect, not proof of total absence.

Every unpatched failure showed the documented signature — an unnamed thread parked in `ThreadStartRoutine`:

```
#4 std::condition_variable::wait(...)
#5 std::condition_variable::wait<...ThreadStartRoutine(void*)::$_0>(...)
#6 ...ThreadStartRoutine (...) at threading_posix.cpp:1321
#7 start_thread ()
```

No patched run lost a thread; all 20 reached an identical state with `GPU Commands` started and shader storage initialised.

DWARF confirms the two binaries genuinely differ — same symbol, opposite line-table state:
- patched: line 1321 starts at `0x43a234 <...ThreadStartRoutine+356>`
- unpatched: line 1321 is at `0x43a299 <...ThreadStartRoutine+457>` but **contains no code**

Per-run md5 audit confirmed all 20 runs of each arm executed the intended binary.

### Methodology, including two runs I threw away

Both of these would have produced a false pass, so they are worth stating:

1. **The first A/B was invalid.** `ThreadStartRoutine` is **statically linked into the consumer executable**, not resolved from `librexruntime*.so`. My first attempt swapped only the shared library, so both arms ran byte-identical unpatched code. Caught because a supposedly patched run still hung with the classic symptom. Anyone reproducing this must rebuild the game binary, not just the library.
2. **A second run was contaminated by two concurrent batch instances** sharing a pinned CPU set. CPU contention *is* the independent variable here, so that data was void. Re-run single-instance under a lockfile; the numbers above come only from the clean run.

Two further caveats for reviewers:

- **Line numbers shift under this patch.** The parked-thread signature is at `threading_posix.cpp:1321` on an unpatched build; grepping for that line on a patched build is grepping the wrong line. Detection above used the thread-id set, which is line-number independent.
- **Neither variant presented a frame within the 20 s window** (`presents=0` in both, same as the baseline measurement). This verifies the thread-start race specifically; it does not demonstrate the title runs to completion or renders.

Single machine, single title, amd64, one 20 s window — the race is timing-dependent and other hardware may weight it differently.

## Notes

Independent of the aarch64 work in #381/#382: this reproduces on stock linux-amd64 by shrinking the CPU set, and the race itself is portable C++ with no arch-specific behaviour. It was originally found on a 4-core aarch64 device, where it hangs on most launches with no CPU restriction at all.

For triage: the `logical_processor_count() >= 6` branch in `xthread.cpp:879` is **not** implicated, despite the failing device logging `Too few processor cores`. Forcing a low reported core count on a 16-CPU machine reproduces nothing; restricting the actual CPU set reproduces it. That branch only correlates because `set_affinity_mask` runs before `Resume()` and its syscall usually delays the parent past the window.
