### PR TITLE
feat(ui): add Wayland and VK_KHR_wayland_surface support

### DIFF
--- a/.github/workflows/_build-platform.yaml
+++ b/.github/workflows/_build-platform.yaml
@@ -61,7 +61,7 @@ jobs:
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev libxss-dev vulkan-sdk \
+            libgtk-3-dev libx11-xcb-dev libxss-dev libwayland-dev vulkan-sdk \
             libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Install build deps (linux-arm64)
@@ -69,7 +69,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev libxss-dev libvulkan-dev glslc glslang-tools \
+            libgtk-3-dev libx11-xcb-dev libxss-dev libwayland-dev libvulkan-dev glslc glslang-tools \
             libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Set up sccache

--- a/include/rex/ui/imgui_drawer.h
+++ b/include/rex/ui/imgui_drawer.h
@@ -119,6 +119,11 @@ class ImGuiDrawer : public WindowInputListener, public UIDrawer {
 
   double frame_time_tick_frequency_;
   uint64_t last_frame_time_ticks_;
+
+  // Mirrors the last ImGuiIO::WantTextInput value applied to window_ via
+  // SetTextInputActive, so it can be cleared if Draw() early-outs (e.g. the
+  // last dialog was just removed) without running another ImGui frame.
+  bool text_input_active_ = false;
 };
 
 }  // namespace ui

--- a/include/rex/ui/surface.h
+++ b/include/rex/ui/surface.h
@@ -31,6 +31,7 @@ class Surface {
     kTypeIndex_AndroidNativeWindow,
     // GNU/Linux.
     kTypeIndex_XcbWindow,
+    kTypeIndex_WaylandSurface,
     // Windows.
     kTypeIndex_Win32Hwnd,
   };
@@ -38,6 +39,7 @@ class Surface {
   enum : TypeFlags {
     kTypeFlag_AndroidNativeWindow = TypeFlags(1) << kTypeIndex_AndroidNativeWindow,
     kTypeFlag_XcbWindow = TypeFlags(1) << kTypeIndex_XcbWindow,
+    kTypeFlag_WaylandSurface = TypeFlags(1) << kTypeIndex_WaylandSurface,
     kTypeFlag_Win32Hwnd = TypeFlags(1) << kTypeIndex_Win32Hwnd,
   };
 

--- a/include/rex/ui/surface_gnulinux.h
+++ b/include/rex/ui/surface_gnulinux.h
@@ -14,6 +14,12 @@
 
 #include <xcb/xcb.h>
 
+struct SDL_Window;
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+struct wl_display;
+struct wl_surface;
+#endif
+
 namespace rex {
 namespace ui {
 
@@ -32,6 +38,25 @@ class XcbWindowSurface final : public Surface {
   xcb_connection_t* connection_;
   xcb_window_t window_;
 };
+
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+class WaylandSurface final : public Surface {
+ public:
+  explicit WaylandSurface(::wl_display* display, ::wl_surface* surface, SDL_Window* sdl_window)
+      : display_(display), surface_(surface), sdl_window_(sdl_window) {}
+  TypeIndex GetType() const override { return kTypeIndex_WaylandSurface; }
+  ::wl_display* display() const { return display_; }
+  ::wl_surface* surface() const { return surface_; }
+
+ protected:
+  bool GetSizeImpl(uint32_t& width_out, uint32_t& height_out) const override;
+
+ private:
+  ::wl_display* display_;
+  ::wl_surface* surface_;
+  SDL_Window* sdl_window_;
+};
+#endif
 
 }  // namespace ui
 }  // namespace rex

--- a/include/rex/ui/vulkan/api.h
+++ b/include/rex/ui/vulkan/api.h
@@ -36,6 +36,9 @@
 #ifndef VK_USE_PLATFORM_XCB_KHR
 #define VK_USE_PLATFORM_XCB_KHR
 #endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <wayland-client.h>
+#endif
 #endif
 
 #if REX_PLATFORM_WIN32

--- a/include/rex/ui/vulkan/functions/instance_khr_wayland_surface.inc
+++ b/include/rex/ui/vulkan/functions/instance_khr_wayland_surface.inc
@@ -1,0 +1,2 @@
+// VK_KHR_wayland_surface functions used in ReXGlue.
+XE_UI_VULKAN_FUNCTION(vkCreateWaylandSurfaceKHR)

--- a/include/rex/ui/vulkan/instance.h
+++ b/include/rex/ui/vulkan/instance.h
@@ -59,6 +59,10 @@ class VulkanInstance {
 #ifdef VK_USE_PLATFORM_XCB_KHR
 #include <rex/ui/vulkan/functions/instance_khr_xcb_surface.inc>
 #endif
+    // VK_KHR_wayland_surface (#7)
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <rex/ui/vulkan/functions/instance_khr_wayland_surface.inc>
+#endif
     // VK_KHR_android_surface (#9)
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 #include <rex/ui/vulkan/functions/instance_khr_android_surface.inc>
@@ -85,6 +89,9 @@ class VulkanInstance {
     bool ext_KHR_surface = false;  // #1
 #ifdef VK_USE_PLATFORM_XCB_KHR
     bool ext_KHR_xcb_surface = false;  // #6
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    bool ext_KHR_wayland_surface = false;  // #7
 #endif
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool ext_KHR_android_surface = false;  // #9

--- a/include/rex/ui/window.h
+++ b/include/rex/ui/window.h
@@ -301,6 +301,10 @@ class Window {
   bool IsMouseCaptureRequested() const { return mouse_capture_request_count_ != 0; }
   void CaptureMouse();
   void ReleaseMouse();
+  virtual void WarpMouseInWindow(int32_t x, int32_t y) {
+    (void)x;
+    (void)y;
+  }
 
   // Desired state stored by the common Window, externally modifiable, read-only
   // in the implementation.

--- a/include/rex/ui/window.h
+++ b/include/rex/ui/window.h
@@ -306,6 +306,14 @@ class Window {
     (void)y;
   }
 
+  // Marks the window as an active text input field (or not) with the OS/
+  // desktop input method. Should be driven by whether a text-entry widget
+  // (e.g. an ImGui InputText) is currently focused, not left on for the
+  // whole session, since that can trigger unwanted IME/input-assist UI
+  // (observed on some desktop environments) while the game just wants
+  // button input. No-op by default.
+  virtual void SetTextInputActive(bool active) { (void)active; }
+
   // Desired state stored by the common Window, externally modifiable, read-only
   // in the implementation.
   CursorVisibility GetCursorVisibility() const { return cursor_visibility_; }

--- a/include/rex/ui/window_sdl.h
+++ b/include/rex/ui/window_sdl.h
@@ -32,6 +32,7 @@ class WindowSDL final : public Window {
   ~WindowSDL() override;
 
   void* GetNativeWindowHandle() const override;
+  void WarpMouseInWindow(int32_t x, int32_t y) override;
 
   // Called by SDLWindowedAppContext on the UI thread.
   void HandleWindowEvent(SDL_Event& event);

--- a/include/rex/ui/window_sdl.h
+++ b/include/rex/ui/window_sdl.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <string_view>
+#include <vector>
 
 #include <SDL3/SDL.h>
 
@@ -33,6 +34,7 @@ class WindowSDL final : public Window {
 
   void* GetNativeWindowHandle() const override;
   void WarpMouseInWindow(int32_t x, int32_t y) override;
+  void SetTextInputActive(bool active) override;
 
   // Called by SDLWindowedAppContext on the UI thread.
   void HandleWindowEvent(SDL_Event& event);
@@ -77,6 +79,13 @@ class WindowSDL final : public Window {
   std::atomic<bool> paint_pending_{false};
   // Auto-hide cursor bookkeeping (CursorVisibility::kAutoHidden).
   SDL_TimerID cursor_hide_timer_ = 0;
+  // Tracks whether SDL_StartTextInput has been called, so SetTextInputActive
+  // only calls SDL when the state actually changes. See SetTextInputActive.
+  bool text_input_active_ = false;
+  // Raw encoded image bytes (e.g. PNG) from the last LoadAndApplyIcon call,
+  // kept so the icon can be (re)applied once the native window exists (see
+  // OpenImpl and the "Icon" contract on Window::OpenImpl).
+  std::vector<uint8_t> icon_data_;
 };
 
 }  // namespace rex::ui

--- a/src/input/mnk/mnk_input_driver.cpp
+++ b/src/input/mnk/mnk_input_driver.cpp
@@ -270,6 +270,8 @@ void MnkInputDriver::CenterCursor() {
     ClientToScreen(hwnd, &pt);
     SetCursorPos(pt.x, pt.y);
   }
+#else
+  attached_window_->WarpMouseInWindow(cx, cy);
 #endif
 }
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -148,6 +148,13 @@ if(NOT WIN32)
     target_link_libraries(rexui PUBLIC
         ${X11_XCB_LIBRARIES}
     )
+
+    pkg_check_modules(WAYLAND QUIET wayland-client)
+    if(WAYLAND_FOUND)
+        target_include_directories(rexui PRIVATE ${WAYLAND_INCLUDE_DIRS})
+        target_link_libraries(rexui PUBLIC ${WAYLAND_LIBRARIES})
+        target_compile_definitions(rexui PUBLIC VK_USE_PLATFORM_WAYLAND_KHR=1)
+    endif()
 endif()
 
 # D3D12 backend dependencies

--- a/src/ui/imgui_drawer.cpp
+++ b/src/ui/imgui_drawer.cpp
@@ -371,6 +371,12 @@ void ImGuiDrawer::Draw(UIDrawContext& ui_draw_context) {
   SetupFontTexture();
 
   if (dialogs_.empty()) {
+    // No dialogs left to want text input (e.g. the last one was just
+    // removed); make sure the window doesn't stay flagged as a text field.
+    if (text_input_active_) {
+      text_input_active_ = false;
+      window_->SetTextInputActive(false);
+    }
     return;
   }
 
@@ -406,6 +412,12 @@ void ImGuiDrawer::Draw(UIDrawContext& ui_draw_context) {
   if (draw_data) {
     RenderDrawLists(draw_data, ui_draw_context);
   }
+
+  // Only mark the window as an active text input field while an ImGui
+  // text-entry widget is actually focused, so the OS/desktop input-assist
+  // UI (IME, autocomplete) doesn't kick in during normal button gameplay.
+  text_input_active_ = io.WantTextInput;
+  window_->SetTextInputActive(text_input_active_);
 
   if (reset_mouse_position_after_next_frame_) {
     reset_mouse_position_after_next_frame_ = false;

--- a/src/ui/surface_gnulinux.cpp
+++ b/src/ui/surface_gnulinux.cpp
@@ -28,5 +28,19 @@ bool XcbWindowSurface::GetSizeImpl(uint32_t& width_out, uint32_t& height_out) co
   return true;
 }
 
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <SDL3/SDL.h>
+
+bool WaylandSurface::GetSizeImpl(uint32_t& width_out, uint32_t& height_out) const {
+  int w = 0, h = 0;
+  if (!SDL_GetWindowSizeInPixels(sdl_window_, &w, &h) || w <= 0 || h <= 0) {
+    return false;
+  }
+  width_out = uint32_t(w);
+  height_out = uint32_t(h);
+  return true;
+}
+#endif
+
 }  // namespace ui
 }  // namespace rex

--- a/src/ui/vulkan/vulkan_instance.cpp
+++ b/src/ui/vulkan/vulkan_instance.cpp
@@ -107,6 +107,11 @@ std::unique_ptr<VulkanInstance> VulkanInstance::Create(const bool with_surface,
     requested_extensions.emplace("VK_KHR_xcb_surface",
                                  &vulkan_instance->extensions_.ext_KHR_xcb_surface);
 #endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    // #7.
+    requested_extensions.emplace("VK_KHR_wayland_surface",
+                                 &vulkan_instance->extensions_.ext_KHR_wayland_surface);
+#endif
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     // #9.
     requested_extensions.emplace("VK_KHR_android_surface",
@@ -368,6 +373,11 @@ std::unique_ptr<VulkanInstance> VulkanInstance::Create(const bool with_surface,
 #ifdef VK_USE_PLATFORM_XCB_KHR
   if (vulkan_instance->extensions_.ext_KHR_xcb_surface) {
 #include <rex/ui/vulkan/functions/instance_khr_xcb_surface.inc>
+  }
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  if (vulkan_instance->extensions_.ext_KHR_wayland_surface) {
+#include <rex/ui/vulkan/functions/instance_khr_wayland_surface.inc>
   }
 #endif
 #ifdef VK_USE_PLATFORM_ANDROID_KHR

--- a/src/ui/vulkan/vulkan_presenter.cpp
+++ b/src/ui/vulkan/vulkan_presenter.cpp
@@ -429,6 +429,11 @@ Surface::TypeFlags VulkanPresenter::GetSurfaceTypesSupportedByInstance(
   if (instance_extensions.ext_KHR_xcb_surface) {
     type_flags |= Surface::kTypeFlag_XcbWindow;
   }
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  if (instance_extensions.ext_KHR_wayland_surface) {
+    type_flags |= Surface::kTypeFlag_WaylandSurface;
+  }
+#endif
 #endif
 #if REX_PLATFORM_WIN32
   if (instance_extensions.ext_KHR_win32_surface) {
@@ -810,6 +815,19 @@ VulkanPresenter::ConnectOrReconnectPaintingToSurfaceFromUIThread(Surface& new_su
         vulkan_surface_create_result = ifn.vkCreateXcbSurfaceKHR(
             instance, &surface_create_info, nullptr, &paint_context_.vulkan_surface);
       } break;
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+      case Surface::kTypeIndex_WaylandSurface: {
+        auto& wayland_surface = static_cast<const WaylandSurface&>(new_surface);
+        VkWaylandSurfaceCreateInfoKHR surface_create_info;
+        surface_create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+        surface_create_info.pNext = nullptr;
+        surface_create_info.flags = 0;
+        surface_create_info.display = wayland_surface.display();
+        surface_create_info.surface = wayland_surface.surface();
+        vulkan_surface_create_result = ifn.vkCreateWaylandSurfaceKHR(
+            instance, &surface_create_info, nullptr, &paint_context_.vulkan_surface);
+      } break;
+#endif
 #endif
 #if REX_PLATFORM_WIN32
       case Surface::kTypeIndex_Win32Hwnd: {

--- a/src/ui/window_sdl.cpp
+++ b/src/ui/window_sdl.cpp
@@ -221,6 +221,12 @@ void* WindowSDL::GetNativeWindowHandle() const {
 #endif
 }
 
+void WindowSDL::WarpMouseInWindow(int32_t x, int32_t y) {
+  if (sdl_window_) {
+    SDL_WarpMouseInWindow(sdl_window_, float(x), float(y));
+  }
+}
+
 uint32_t WindowSDL::GetLatestDpiImpl() const {
   float scale = sdl_window_ ? SDL_GetWindowDisplayScale(sdl_window_)
                             : SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
@@ -246,10 +252,16 @@ void WindowSDL::ApplyNewTitle() {
 
 void WindowSDL::ApplyNewMouseCapture() {
   SDL_CaptureMouse(true);
+  if (sdl_window_) {
+    SDL_StopTextInput(sdl_window_);
+  }
 }
 
 void WindowSDL::ApplyNewMouseRelease() {
   SDL_CaptureMouse(false);
+  if (sdl_window_) {
+    SDL_StartTextInput(sdl_window_);
+  }
 }
 
 void WindowSDL::ApplyNewCursorVisibility(CursorVisibility old_cursor_visibility) {
@@ -312,6 +324,17 @@ std::unique_ptr<Surface> WindowSDL::CreateSurfaceImpl(Surface::TypeFlags allowed
     }
   }
 #else
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  if (allowed_types & Surface::kTypeFlag_WaylandSurface) {
+    auto* wl_display_ptr = static_cast<struct wl_display*>(
+        SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER, nullptr));
+    auto* wl_surface_ptr = static_cast<struct wl_surface*>(
+        SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER, nullptr));
+    if (wl_display_ptr && wl_surface_ptr) {
+      return std::make_unique<WaylandSurface>(wl_display_ptr, wl_surface_ptr, sdl_window_);
+    }
+  }
+#endif
   if (allowed_types & Surface::kTypeFlag_XcbWindow) {
     auto* display = static_cast<Display*>(
         SDL_GetPointerProperty(props, SDL_PROP_WINDOW_X11_DISPLAY_POINTER, nullptr));

--- a/src/ui/window_sdl.cpp
+++ b/src/ui/window_sdl.cpp
@@ -161,8 +161,14 @@ bool WindowSDL::OpenImpl() {
     // Borderless desktop fullscreen (a NULL display mode is SDL3's default).
     SDL_SetWindowFullscreen(sdl_window_, true);
   }
-  // SDL3 requires explicit opt-in for text input events.
-  SDL_StartTextInput(sdl_window_);
+  // SDL3 requires explicit opt-in for text input events. We only want the
+  // character events (e.g. for ImGui overlays), not an OS on-screen keyboard
+  // popping up unprompted (observed on SteamOS/gamescope). Text input itself
+  // is left off until a text-entry widget is actually focused (see
+  // SetTextInputActive) so the window isn't flagged as an active text field
+  // for the whole session, which can trigger unwanted desktop input-assist
+  // UI (IME candidate windows, autocomplete) during normal gameplay.
+  SDL_SetHint(SDL_HINT_ENABLE_SCREEN_KEYBOARD, "0");
   ApplyCursorVisibilityNow();
   SDL_ShowWindow(sdl_window_);
 
@@ -252,15 +258,21 @@ void WindowSDL::ApplyNewTitle() {
 
 void WindowSDL::ApplyNewMouseCapture() {
   SDL_CaptureMouse(true);
-  if (sdl_window_) {
-    SDL_StopTextInput(sdl_window_);
-  }
 }
 
 void WindowSDL::ApplyNewMouseRelease() {
   SDL_CaptureMouse(false);
-  if (sdl_window_) {
+}
+
+void WindowSDL::SetTextInputActive(bool active) {
+  if (!sdl_window_ || text_input_active_ == active) {
+    return;
+  }
+  text_input_active_ = active;
+  if (active) {
     SDL_StartTextInput(sdl_window_);
+  } else {
+    SDL_StopTextInput(sdl_window_);
   }
 }
 

--- a/src/ui/windowed_app_context_sdl.cpp
+++ b/src/ui/windowed_app_context_sdl.cpp
@@ -31,10 +31,7 @@ SDLWindowedAppContext::~SDLWindowedAppContext() {
 }
 
 bool SDLWindowedAppContext::Initialize() {
-#if !REX_PLATFORM_WIN32
-  // The Surface types the presenters consume are Win32Hwnd and XcbWindow;
-  // force X11 so an xcb connection is retrievable (there is no Wayland
-  // surface type).
+#if !REX_PLATFORM_WIN32 && !defined(VK_USE_PLATFORM_WAYLAND_KHR)
   SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "x11");
 #endif
   if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {


### PR DESCRIPTION
Implements #317. I've been testing this on my [NocturneRecomp](https://github.com/birabittoh/NocturneRecomp) project for a few weeks and it's been working on many linux distros and desktop environments, including SteamOS.

* The feature commit contains the actual Wayland implementation
* The fix commit addresses an issue that many people ran into when playing my game on SteamOS: the virtual keyboard was popping up as soon as the game started, the special characters overlay was conflicting with letter inputs when trying to use keyboard controls. With this fix, these tools should only activate while the user is actually typing on an input field.