### PR TITLE
feat(ui): add Wayland and VK_KHR_wayland_surface support with SDL3 backend

### DIFF
--- a/.github/workflows/_build-platform.yaml
+++ b/.github/workflows/_build-platform.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev libxss-dev vulkan-sdk \
+            libgtk-3-dev libx11-xcb-dev libxss-dev libwayland-dev vulkan-sdk \
             libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Install build deps (linux-arm64)
@@ -73,7 +73,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y cmake ninja-build build-essential git curl unzip autoconf python3.12-venv \
-            libgtk-3-dev libx11-xcb-dev libxss-dev libvulkan-dev glslc glslang-tools \
+            libgtk-3-dev libx11-xcb-dev libxss-dev libwayland-dev libvulkan-dev glslc glslang-tools \
             libasound2-dev libpulse-dev libpipewire-0.3-dev
 
       - name: Set up sccache

--- a/include/rex/input/mnk/mnk_input_driver.h
+++ b/include/rex/input/mnk/mnk_input_driver.h
@@ -54,7 +54,6 @@ class MnkInputDriver final : public InputDriver,
 
  private:
   bool IsEnabled() const;
-  void CenterCursor();
   void UpdateMouseCapture();
   void SetKeyState(uint16_t vk, bool down);
   void EnqueueKeystroke(uint16_t vk_pad, bool down);
@@ -70,6 +69,10 @@ class MnkInputDriver final : public InputDriver,
   int32_t prev_mouse_x_ = 0;
   int32_t prev_mouse_y_ = 0;
   bool mouse_captured_ = false;
+  // True while the window has the pointer locked and is reporting relative
+  // motion, in which case MouseEvent::dx/dy are used directly instead of
+  // differencing absolute positions.
+  bool relative_mouse_mode_ = false;
   // Cursor visibility to restore on capture release - the window owner may run
   // an auto-hide policy that capture must not permanently override.
   rex::ui::Window::CursorVisibility precapture_cursor_visibility_ =

--- a/include/rex/ui/surface.h
+++ b/include/rex/ui/surface.h
@@ -31,6 +31,7 @@ class Surface {
     kTypeIndex_AndroidNativeWindow,
     // GNU/Linux.
     kTypeIndex_XcbWindow,
+    kTypeIndex_WaylandSurface,
     // Windows.
     kTypeIndex_Win32Hwnd,
     // macOS — CAMetalLayer presented via MoltenVK (VK_EXT_metal_surface).
@@ -40,6 +41,7 @@ class Surface {
   enum : TypeFlags {
     kTypeFlag_AndroidNativeWindow = TypeFlags(1) << kTypeIndex_AndroidNativeWindow,
     kTypeFlag_XcbWindow = TypeFlags(1) << kTypeIndex_XcbWindow,
+    kTypeFlag_WaylandSurface = TypeFlags(1) << kTypeIndex_WaylandSurface,
     kTypeFlag_Win32Hwnd = TypeFlags(1) << kTypeIndex_Win32Hwnd,
     kTypeFlag_CAMetalLayer = TypeFlags(1) << kTypeIndex_CAMetalLayer,
   };

--- a/include/rex/ui/surface_gnulinux.h
+++ b/include/rex/ui/surface_gnulinux.h
@@ -14,6 +14,12 @@
 
 #include <xcb/xcb.h>
 
+struct SDL_Window;
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+struct wl_display;
+struct wl_surface;
+#endif
+
 namespace rex {
 namespace ui {
 
@@ -32,6 +38,25 @@ class XcbWindowSurface final : public Surface {
   xcb_connection_t* connection_;
   xcb_window_t window_;
 };
+
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+class WaylandSurface final : public Surface {
+ public:
+  explicit WaylandSurface(::wl_display* display, ::wl_surface* surface, SDL_Window* sdl_window)
+      : display_(display), surface_(surface), sdl_window_(sdl_window) {}
+  TypeIndex GetType() const override { return kTypeIndex_WaylandSurface; }
+  ::wl_display* display() const { return display_; }
+  ::wl_surface* surface() const { return surface_; }
+
+ protected:
+  bool GetSizeImpl(uint32_t& width_out, uint32_t& height_out) const override;
+
+ private:
+  ::wl_display* display_;
+  ::wl_surface* surface_;
+  SDL_Window* sdl_window_;
+};
+#endif
 
 }  // namespace ui
 }  // namespace rex

--- a/include/rex/ui/ui_event.h
+++ b/include/rex/ui/ui_event.h
@@ -126,8 +126,15 @@ class MouseEvent : public UIEvent {
   static constexpr uint32_t kScrollPerDetent = 120;
 
   explicit MouseEvent(Window* target, Button button, int32_t x, int32_t y, int32_t scroll_x = 0,
-                      int32_t scroll_y = 0)
-      : UIEvent(target), button_(button), x_(x), y_(y), scroll_x_(scroll_x), scroll_y_(scroll_y) {}
+                      int32_t scroll_y = 0, int32_t dx = 0, int32_t dy = 0)
+      : UIEvent(target),
+        button_(button),
+        x_(x),
+        y_(y),
+        scroll_x_(scroll_x),
+        scroll_y_(scroll_y),
+        dx_(dx),
+        dy_(dy) {}
   ~MouseEvent() override = default;
 
   bool is_handled() const { return handled_; }
@@ -138,6 +145,11 @@ class MouseEvent : public UIEvent {
   int32_t y() const { return y_; }
   int32_t scroll_x() const { return scroll_x_; }
   int32_t scroll_y() const { return scroll_y_; }
+  // Movement since the previous motion event, as reported by the platform.
+  // Unlike x()/y() deltas these stay meaningful while the pointer is locked
+  // by Window::SetRelativeMouseMode, where the position no longer moves.
+  int32_t dx() const { return dx_; }
+  int32_t dy() const { return dy_; }
 
  private:
   bool handled_ = false;
@@ -147,6 +159,8 @@ class MouseEvent : public UIEvent {
   int32_t scroll_x_ = 0;
   // Positive is up (away from the user), negative is down (towards the user).
   int32_t scroll_y_ = 0;
+  int32_t dx_ = 0;
+  int32_t dy_ = 0;
 };
 
 class TouchEvent : public UIEvent {

--- a/include/rex/ui/vulkan/api.h
+++ b/include/rex/ui/vulkan/api.h
@@ -36,6 +36,9 @@
 #ifndef VK_USE_PLATFORM_XCB_KHR
 #define VK_USE_PLATFORM_XCB_KHR
 #endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <wayland-client.h>
+#endif
 #endif
 
 #if REX_PLATFORM_WIN32

--- a/include/rex/ui/vulkan/functions/instance_khr_wayland_surface.inc
+++ b/include/rex/ui/vulkan/functions/instance_khr_wayland_surface.inc
@@ -1,0 +1,2 @@
+// VK_KHR_wayland_surface functions used in ReXGlue.
+XE_UI_VULKAN_FUNCTION(vkCreateWaylandSurfaceKHR)

--- a/include/rex/ui/vulkan/instance.h
+++ b/include/rex/ui/vulkan/instance.h
@@ -59,6 +59,10 @@ class VulkanInstance {
 #ifdef VK_USE_PLATFORM_XCB_KHR
 #include <rex/ui/vulkan/functions/instance_khr_xcb_surface.inc>
 #endif
+    // VK_KHR_wayland_surface (#7)
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <rex/ui/vulkan/functions/instance_khr_wayland_surface.inc>
+#endif
     // VK_KHR_android_surface (#9)
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 #include <rex/ui/vulkan/functions/instance_khr_android_surface.inc>
@@ -89,6 +93,9 @@ class VulkanInstance {
     bool ext_KHR_surface = false;  // #1
 #ifdef VK_USE_PLATFORM_XCB_KHR
     bool ext_KHR_xcb_surface = false;  // #6
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    bool ext_KHR_wayland_surface = false;  // #7
 #endif
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool ext_KHR_android_surface = false;  // #9

--- a/include/rex/ui/window.h
+++ b/include/rex/ui/window.h
@@ -301,6 +301,16 @@ class Window {
   bool IsMouseCaptureRequested() const { return mouse_capture_request_count_ != 0; }
   void CaptureMouse();
   void ReleaseMouse();
+  // Locks the pointer to the window and switches mouse motion events to
+  // relative deltas (MouseEvent::dx/dy), for mouse-look style input. Warping
+  // the pointer to re-center it is not usable for this: Wayland compositors
+  // reject client pointer warps outside of an explicit pointer lock, so the
+  // platform's own relative-motion path has to be used instead. Returns true
+  // if relative mode is active afterwards. No-op returning false by default.
+  virtual bool SetRelativeMouseMode(bool enable) {
+    (void)enable;
+    return false;
+  }
 
   // Desired state stored by the common Window, externally modifiable, read-only
   // in the implementation.

--- a/include/rex/ui/window_sdl.h
+++ b/include/rex/ui/window_sdl.h
@@ -32,6 +32,7 @@ class WindowSDL final : public Window {
   ~WindowSDL() override;
 
   void* GetNativeWindowHandle() const override;
+  bool SetRelativeMouseMode(bool enable) override;
 
   // Called by SDLWindowedAppContext on the UI thread.
   void HandleWindowEvent(SDL_Event& event);

--- a/src/input/mnk/mnk_input_driver.cpp
+++ b/src/input/mnk/mnk_input_driver.cpp
@@ -22,10 +22,6 @@
 #include <cstring>
 #include <string_view>
 
-#if REX_PLATFORM_WIN32
-#include <Windows.h>
-#endif
-
 REXCVAR_DEFINE_BOOL(mnk_mode, false, "Input", "Enable keyboard/mouse controller emulation");
 REXCVAR_DEFINE_BOOL(mnk_mouse, false, "Input",
                     "Use the mouse for the right stick. Off means the right stick comes "
@@ -171,6 +167,8 @@ void MnkInputDriver::OnClosing(rex::ui::UIEvent&) {
     if (mouse_captured_) {
       mouse_captured_ = false;
       attached_window_->SetCursorVisibility(precapture_cursor_visibility_);
+      attached_window_->SetRelativeMouseMode(false);
+      relative_mouse_mode_ = false;
       attached_window_->ReleaseMouse();
     }
     attached_window_->RemoveInputListener(this);
@@ -376,23 +374,6 @@ void MnkInputDriver::EnqueueKeystroke(uint16_t vk_pad, bool down) {
   keystroke_queue_.push(ks);
 }
 
-void MnkInputDriver::CenterCursor() {
-  if (!attached_window_)
-    return;
-  int32_t cx = static_cast<int32_t>(attached_window_->GetActualLogicalWidth() / 2);
-  int32_t cy = static_cast<int32_t>(attached_window_->GetActualLogicalHeight() / 2);
-  prev_mouse_x_ = cx;
-  prev_mouse_y_ = cy;
-#if REX_PLATFORM_WIN32
-  HWND hwnd = static_cast<HWND>(attached_window_->GetNativeWindowHandle());
-  if (hwnd) {
-    POINT pt = {static_cast<LONG>(cx), static_cast<LONG>(cy)};
-    ClientToScreen(hwnd, &pt);
-    SetCursorPos(pt.x, pt.y);
-  }
-#endif
-}
-
 void MnkInputDriver::UpdateMouseCapture() {
   if (!attached_window_)
     return;
@@ -407,18 +388,20 @@ void MnkInputDriver::UpdateMouseCapture() {
     precapture_cursor_visibility_ = attached_window_->GetCursorVisibility();
     attached_window_->SetCursorVisibility(rex::ui::Window::CursorVisibility::kHidden);
     attached_window_->CaptureMouse();
+    // Lock the pointer so mouse-look isn't clamped at the window edge. This
+    // replaces warping the cursor back to the center every frame, which
+    // Wayland compositors reject. If the platform can't lock the pointer we
+    // fall back to absolute-position deltas, as before.
+    relative_mouse_mode_ = attached_window_->SetRelativeMouseMode(true);
     // Reset deltas to avoid a spike on capture start
     mouse_dx_ = 0;
     mouse_dy_ = 0;
   } else if (!should_capture && mouse_captured_) {
     mouse_captured_ = false;
     attached_window_->SetCursorVisibility(precapture_cursor_visibility_);
+    attached_window_->SetRelativeMouseMode(false);
+    relative_mouse_mode_ = false;
     attached_window_->ReleaseMouse();
-  }
-
-  // Re-center cursor each frame while captured to prevent edge clamping
-  if (mouse_captured_) {
-    CenterCursor();
   }
 }
 
@@ -488,8 +471,14 @@ void MnkInputDriver::OnMouseMove(rex::ui::MouseEvent& e) {
   std::lock_guard lock(state_mutex_);
   int32_t x = e.x();
   int32_t y = e.y();
-  mouse_dx_ += x - prev_mouse_x_;
-  mouse_dy_ += y - prev_mouse_y_;
+  if (relative_mouse_mode_) {
+    // The pointer is locked; absolute positions no longer move.
+    mouse_dx_ += e.dx();
+    mouse_dy_ += e.dy();
+  } else {
+    mouse_dx_ += x - prev_mouse_x_;
+    mouse_dy_ += y - prev_mouse_y_;
+  }
   prev_mouse_x_ = x;
   prev_mouse_y_ = y;
 }
@@ -503,6 +492,8 @@ void MnkInputDriver::OnLostFocus(rex::ui::UISetupEvent&) {
   if (mouse_captured_ && attached_window_) {
     mouse_captured_ = false;
     attached_window_->SetCursorVisibility(precapture_cursor_visibility_);
+    attached_window_->SetRelativeMouseMode(false);
+    relative_mouse_mode_ = false;
     attached_window_->ReleaseMouse();
   }
 }

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -156,6 +156,16 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(rexui PUBLIC
         ${X11_XCB_LIBRARIES}
     )
+
+    pkg_check_modules(WAYLAND QUIET wayland-client)
+    if(WAYLAND_FOUND)
+        # PUBLIC: VK_USE_PLATFORM_WAYLAND_KHR makes vulkan/api.h include
+        # <wayland-client.h>, so every consumer of that header needs the
+        # include path, not just rexui itself.
+        target_include_directories(rexui PUBLIC ${WAYLAND_INCLUDE_DIRS})
+        target_link_libraries(rexui PUBLIC ${WAYLAND_LIBRARIES})
+        target_compile_definitions(rexui PUBLIC VK_USE_PLATFORM_WAYLAND_KHR=1)
+    endif()
 elseif(APPLE)
     target_link_libraries(rexui PRIVATE "-framework CoreFoundation")
 endif()

--- a/src/ui/surface_gnulinux.cpp
+++ b/src/ui/surface_gnulinux.cpp
@@ -11,6 +11,10 @@
 
 #include <cstdlib>
 
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <SDL3/SDL.h>
+#endif
+
 #include <rex/ui/surface_gnulinux.h>
 
 namespace rex {
@@ -27,6 +31,18 @@ bool XcbWindowSurface::GetSizeImpl(uint32_t& width_out, uint32_t& height_out) co
   std::free(reply);
   return true;
 }
+
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+bool WaylandSurface::GetSizeImpl(uint32_t& width_out, uint32_t& height_out) const {
+  int w = 0, h = 0;
+  if (!SDL_GetWindowSizeInPixels(sdl_window_, &w, &h) || w <= 0 || h <= 0) {
+    return false;
+  }
+  width_out = uint32_t(w);
+  height_out = uint32_t(h);
+  return true;
+}
+#endif
 
 }  // namespace ui
 }  // namespace rex

--- a/src/ui/vulkan/vulkan_instance.cpp
+++ b/src/ui/vulkan/vulkan_instance.cpp
@@ -145,6 +145,11 @@ std::unique_ptr<VulkanInstance> VulkanInstance::Create(const bool with_surface,
     requested_extensions.emplace("VK_KHR_xcb_surface",
                                  &vulkan_instance->extensions_.ext_KHR_xcb_surface);
 #endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    // #7.
+    requested_extensions.emplace("VK_KHR_wayland_surface",
+                                 &vulkan_instance->extensions_.ext_KHR_wayland_surface);
+#endif
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     // #9.
     requested_extensions.emplace("VK_KHR_android_surface",
@@ -411,6 +416,11 @@ std::unique_ptr<VulkanInstance> VulkanInstance::Create(const bool with_surface,
 #ifdef VK_USE_PLATFORM_XCB_KHR
   if (vulkan_instance->extensions_.ext_KHR_xcb_surface) {
 #include <rex/ui/vulkan/functions/instance_khr_xcb_surface.inc>
+  }
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  if (vulkan_instance->extensions_.ext_KHR_wayland_surface) {
+#include <rex/ui/vulkan/functions/instance_khr_wayland_surface.inc>
   }
 #endif
 #ifdef VK_USE_PLATFORM_ANDROID_KHR

--- a/src/ui/vulkan/vulkan_presenter.cpp
+++ b/src/ui/vulkan/vulkan_presenter.cpp
@@ -432,6 +432,11 @@ Surface::TypeFlags VulkanPresenter::GetSurfaceTypesSupportedByInstance(
   if (instance_extensions.ext_KHR_xcb_surface) {
     type_flags |= Surface::kTypeFlag_XcbWindow;
   }
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  if (instance_extensions.ext_KHR_wayland_surface) {
+    type_flags |= Surface::kTypeFlag_WaylandSurface;
+  }
+#endif
 #endif
 #if REX_PLATFORM_WIN32
   if (instance_extensions.ext_KHR_win32_surface) {
@@ -818,6 +823,19 @@ VulkanPresenter::ConnectOrReconnectPaintingToSurfaceFromUIThread(Surface& new_su
         vulkan_surface_create_result = ifn.vkCreateXcbSurfaceKHR(
             instance, &surface_create_info, nullptr, &paint_context_.vulkan_surface);
       } break;
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+      case Surface::kTypeIndex_WaylandSurface: {
+        auto& wayland_surface = static_cast<const WaylandSurface&>(new_surface);
+        VkWaylandSurfaceCreateInfoKHR surface_create_info;
+        surface_create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+        surface_create_info.pNext = nullptr;
+        surface_create_info.flags = 0;
+        surface_create_info.display = wayland_surface.display();
+        surface_create_info.surface = wayland_surface.surface();
+        vulkan_surface_create_result = ifn.vkCreateWaylandSurfaceKHR(
+            instance, &surface_create_info, nullptr, &paint_context_.vulkan_surface);
+      } break;
+#endif
 #endif
 #if REX_PLATFORM_WIN32
       case Surface::kTypeIndex_Win32Hwnd: {

--- a/src/ui/window_sdl.cpp
+++ b/src/ui/window_sdl.cpp
@@ -238,6 +238,17 @@ void* WindowSDL::GetNativeWindowHandle() const {
 #endif
 }
 
+bool WindowSDL::SetRelativeMouseMode(bool enable) {
+  if (!sdl_window_) {
+    return false;
+  }
+  if (!SDL_SetWindowRelativeMouseMode(sdl_window_, enable)) {
+    REXLOG_WARN("SDL_SetWindowRelativeMouseMode({}) failed: {}", enable, SDL_GetError());
+    return false;
+  }
+  return enable;
+}
+
 uint32_t WindowSDL::GetLatestDpiImpl() const {
   float scale = sdl_window_ ? SDL_GetWindowDisplayScale(sdl_window_)
                             : SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
@@ -341,6 +352,17 @@ std::unique_ptr<Surface> WindowSDL::CreateSurfaceImpl(Surface::TypeFlags allowed
   }
 #else
   SDL_PropertiesID props = SDL_GetWindowProperties(sdl_window_);
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  if (allowed_types & Surface::kTypeFlag_WaylandSurface) {
+    auto* wl_display_ptr = static_cast<struct wl_display*>(
+        SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER, nullptr));
+    auto* wl_surface_ptr = static_cast<struct wl_surface*>(
+        SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER, nullptr));
+    if (wl_display_ptr && wl_surface_ptr) {
+      return std::make_unique<WaylandSurface>(wl_display_ptr, wl_surface_ptr, sdl_window_);
+    }
+  }
+#endif
   if (allowed_types & Surface::kTypeFlag_XcbWindow) {
     auto* display = static_cast<Display*>(
         SDL_GetPointerProperty(props, SDL_PROP_WINDOW_X11_DISPLAY_POINTER, nullptr));
@@ -494,7 +516,8 @@ void WindowSDL::HandleMouseEvent(SDL_Event& event) {
         RearmCursorAutoHideTimer();
       }
       MouseEvent e(this, MouseEvent::Button::kNone, int32_t(event.motion.x * density),
-                   int32_t(event.motion.y * density));
+                   int32_t(event.motion.y * density), 0, 0, int32_t(event.motion.xrel * density),
+                   int32_t(event.motion.yrel * density));
       OnMouseMove(e, destruction_receiver);
       break;
     }

--- a/src/ui/windowed_app_context_sdl.cpp
+++ b/src/ui/windowed_app_context_sdl.cpp
@@ -38,10 +38,9 @@ bool SDLWindowedAppContext::Initialize() {
 #if REX_PLATFORM_MAC
   // macOS presents via a CAMetalLayer surface obtained from the Cocoa driver.
   SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "cocoa");
-#elif !REX_PLATFORM_WIN32
-  // The Surface types the presenters consume are Win32Hwnd and XcbWindow;
-  // force X11 so an xcb connection is retrievable (there is no Wayland
-  // surface type).
+#elif !REX_PLATFORM_WIN32 && !defined(VK_USE_PLATFORM_WAYLAND_KHR)
+  // The Surface types the presenters consume without Wayland are Win32Hwnd
+  // and XcbWindow; force X11 so an xcb connection is retrievable.
   SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "x11");
 #endif
   if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {


### PR DESCRIPTION
Follow-up to #391, addresses #317.

Add a WaylandSurface surface type and the VK_KHR_wayland_surface instance extension, and stop forcing SDL_HINT_VIDEO_DRIVER=x11 when the Wayland path is compiled in, so a native Wayland session no longer has to go through XWayland.

Mouse-look re-centered the pointer every frame via SDL_WarpMouseInWindow, which on development was a no-op on Linux (GetNativeWindowHandle returns nullptr there). Warping does work under a native Wayland session with the SDL3 we link, which emulates it, but it depends on that emulation and on the compositor cooperating rather than on a mechanism the protocol actually provides. Replace it with Window::SetRelativeMouseMode, backed by SDL_SetWindowRelativeMouseMode, and carry the platform's relative motion through MouseEvent::dx/dy. This also removes the Win32 SetCursorPos special-case instead of adding a second platform branch beside it.

The mnk driver uses the relative deltas while the pointer is locked and falls back to absolute-position differencing if the platform refuses the lock, so it can't regress anywhere the old path worked.