### PR TITLE
fix(ui): only activate text input while an ImGui field is focused

### DIFF
--- a/include/rex/ui/imgui_drawer.h
+++ b/include/rex/ui/imgui_drawer.h
@@ -119,6 +119,11 @@ class ImGuiDrawer : public WindowInputListener, public UIDrawer {
 
   double frame_time_tick_frequency_;
   uint64_t last_frame_time_ticks_;
+
+  // Mirrors the last ImGuiIO::WantTextInput value applied to window_ via
+  // SetTextInputActive, so DetachIfLastDialogRemoved can clear it without
+  // running another ImGui frame (after detaching there won't be one).
+  bool text_input_active_ = false;
 };
 
 }  // namespace ui

--- a/include/rex/ui/window.h
+++ b/include/rex/ui/window.h
@@ -302,6 +302,14 @@ class Window {
   void CaptureMouse();
   void ReleaseMouse();
 
+  // Marks the window as an active text input field (or not) with the OS/
+  // desktop input method. Should be driven by whether a text-entry widget
+  // (e.g. an ImGui InputText) is currently focused, not left on for the
+  // whole session, since that can trigger unwanted IME/input-assist UI
+  // (observed on some desktop environments) while the game just wants
+  // button input. No-op by default.
+  virtual void SetTextInputActive(bool active) { (void)active; }
+
   // Desired state stored by the common Window, externally modifiable, read-only
   // in the implementation.
   CursorVisibility GetCursorVisibility() const { return cursor_visibility_; }

--- a/include/rex/ui/window_sdl.h
+++ b/include/rex/ui/window_sdl.h
@@ -32,6 +32,7 @@ class WindowSDL final : public Window {
   ~WindowSDL() override;
 
   void* GetNativeWindowHandle() const override;
+  void SetTextInputActive(bool active) override;
 
   // Called by SDLWindowedAppContext on the UI thread.
   void HandleWindowEvent(SDL_Event& event);
@@ -76,6 +77,9 @@ class WindowSDL final : public Window {
   std::atomic<bool> paint_pending_{false};
   // Auto-hide cursor bookkeeping (CursorVisibility::kAutoHidden).
   SDL_TimerID cursor_hide_timer_ = 0;
+  // Tracks whether SDL_StartTextInput has been called, so SetTextInputActive
+  // only calls SDL when the state actually changes. See SetTextInputActive.
+  bool text_input_active_ = false;
 };
 
 }  // namespace rex::ui

--- a/src/ui/imgui_drawer.cpp
+++ b/src/ui/imgui_drawer.cpp
@@ -407,6 +407,12 @@ void ImGuiDrawer::Draw(UIDrawContext& ui_draw_context) {
     RenderDrawLists(draw_data, ui_draw_context);
   }
 
+  // Only mark the window as an active text input field while an ImGui
+  // text-entry widget is actually focused, so the OS/desktop input-assist
+  // UI (IME, autocomplete) doesn't kick in during normal button gameplay.
+  text_input_active_ = io.WantTextInput;
+  window_->SetTextInputActive(text_input_active_);
+
   if (reset_mouse_position_after_next_frame_) {
     reset_mouse_position_after_next_frame_ = false;
     io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
@@ -648,6 +654,13 @@ void ImGuiDrawer::DetachIfLastDialogRemoved() {
   // times in the current frame.
   if (!dialogs_.empty() || IsDrawingDialogs()) {
     return;
+  }
+  // Detaching stops Draw from being called, so the text input state has to be
+  // cleared here: the dialog being removed may have had a focused InputText,
+  // and there is no later frame in which to notice that it's gone.
+  if (text_input_active_) {
+    text_input_active_ = false;
+    window_->SetTextInputActive(false);
   }
   if (presenter_) {
     presenter_->RemoveUIDrawerFromUIThread(this);

--- a/src/ui/window_sdl.cpp
+++ b/src/ui/window_sdl.cpp
@@ -178,8 +178,12 @@ bool WindowSDL::OpenImpl() {
                            kCFPreferencesCurrentApplication);
   CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 #endif
-  // SDL3 requires explicit opt-in for text input events.
-  SDL_StartTextInput(sdl_window_);
+  // SDL3 requires explicit opt-in for text input events, but it is not
+  // enabled here: leaving it on for the whole session flags the window as an
+  // active text field, which makes the desktop's input assist (on-screen
+  // keyboard on SteamOS/gamescope, IME candidate windows, autocomplete) show
+  // up during normal button-only gameplay. It is turned on by
+  // SetTextInputActive only while a text-entry widget is focused.
   ApplyCursorVisibilityNow();
   SDL_ShowWindow(sdl_window_);
 
@@ -267,6 +271,18 @@ void WindowSDL::ApplyNewMouseCapture() {
 
 void WindowSDL::ApplyNewMouseRelease() {
   SDL_CaptureMouse(false);
+}
+
+void WindowSDL::SetTextInputActive(bool active) {
+  if (!sdl_window_ || text_input_active_ == active) {
+    return;
+  }
+  text_input_active_ = active;
+  if (active) {
+    SDL_StartTextInput(sdl_window_);
+  } else {
+    SDL_StopTextInput(sdl_window_);
+  }
 }
 
 void WindowSDL::ApplyNewCursorVisibility(CursorVisibility old_cursor_visibility) {


### PR DESCRIPTION
Follow up of #391.

SDL_StartTextInput was called unconditionally in WindowSDL::OpenImpl, permanently flagging the window as an active text field in SDL3. That makes the desktop's input assist kick in during normal button-only gameplay: an on-screen keyboard popping up at launch on SteamOS, and IME candidate windows / autocomplete on some desktop environments.

Add Window::SetTextInputActive and drive it from ImGuiIO::WantTextInput each frame, so SDL text input is only active while a text-entry widget (XamShowKeyboardUI dialog, dev console) is actually focused. This keeps the on-screen keyboard available where it's needed, which matters for Deck users with no physical keyboard.

Closing the last dialog detaches the drawer from the presenter, so no further frame runs; the flag is cleared in DetachIfLastDialogRemoved rather than on a subsequent frame that would never come.