### PR TITLE
Audio stretch fix: keep SDL timer resolution enabled

### DIFF
--- a/src/audio/sdl/sdl_audio_driver.cpp
+++ b/src/audio/sdl/sdl_audio_driver.cpp
@@ -37,10 +37,6 @@ SDLAudioDriver::~SDLAudioDriver() {
 }
 
 bool SDLAudioDriver::Initialize() {
-  // Guest workloads use millisecond-scale waits. Keep SDL's normal Windows
-  // timer resolution so those waits don't get rounded up.
-  SDL_SetHintWithPriority(SDL_HINT_TIMER_RESOLUTION, "1", SDL_HINT_OVERRIDE);
-
   // Set audio category for proper OS audio handling
   SDL_SetHint(SDL_HINT_AUDIO_CATEGORY, "playback");
 

--- a/src/audio/sdl/sdl_audio_driver.cpp
+++ b/src/audio/sdl/sdl_audio_driver.cpp
@@ -37,8 +37,9 @@ SDLAudioDriver::~SDLAudioDriver() {
 }
 
 bool SDLAudioDriver::Initialize() {
-  // Prevent SDL from interfering with timer resolution (causes FPS drops)
-  SDL_SetHintWithPriority(SDL_HINT_TIMER_RESOLUTION, "0", SDL_HINT_OVERRIDE);
+  // Guest workloads use millisecond-scale waits. Keep SDL's normal Windows
+  // timer resolution so those waits don't get rounded up.
+  SDL_SetHintWithPriority(SDL_HINT_TIMER_RESOLUTION, "1", SDL_HINT_OVERRIDE);
 
   // Set audio category for proper OS audio handling
   SDL_SetHint(SDL_HINT_AUDIO_CATEGORY, "playback");


### PR DESCRIPTION
The SDL audio setup was turning off Windows' high-resolution timer:

```cpp
SDL_SetHintWithPriority(SDL_HINT_TIMER_RESOLUTION, "0", SDL_HINT_OVERRIDE);
```
This is a one-character behavior change in `SDLAudioDriver::Initialize`. SDL documents `1` as its default on Windows. The problem came from the driver explicitly overriding that default with `0`.

I'm not sure how relevant the "_Prevent SDL from interfering with timer resolution (causes FPS drops)_" comment is here. I don't really encounter any problems. 

----------------------------------------

I had two builds, one with SDL and the other with XAudio2, for juxtaposition.

The test builds  logged:

- guest render callbacks and submissions;
- backend completions and queue depth;
- callback timing;
- source, stream, and device formats;
- FM2 scheduler, pump, and codec-read rates; and
- guest clock and output frequency ratios.

Both the broken and fixed builds submitted about 187 to 188 blocks per second.
That count alone made the SDL path look healthy.

The _contents_ were not healthy. Before the fix, more than half of the blocks were old data. Every duplicate matched the block from four submissions earlier.

-----------------------------------

| Run | Blocks checked | Unique | Repeated | Codec reads/s |
| --- | ---: | ---: | ---: | ---: |
| SDL before fix | 1,875 | 823 | 1,052 (56.1%) | 38-46 |
| XAudio2 | 1,875 | 1,875 | 0 | 91-94 |
| SDL after fix | 1,875 | 1,875 | 0 | 92-94 |

FM2 reads stereo PCM in 2,048-byte chunks:

```text
48,000 frames/s * 2 channels * 2 bytes = 192,000 bytes/s
192,000 / 2,048 = 93.75 reads/s
```

Before the fix, FM2 only read about 78 to 94 KB per second instead of the
required 192 KB. The missing data lined up with the percentage of repeated
audio blocks.

