### PR TITLE
fix(net): create guest sockets non-blocking

### DIFF
--- a/include/rex/net/socket.h
+++ b/include/rex/net/socket.h
@@ -14,4 +14,10 @@ constexpr SocketHandle kInvalidSocket = -1;
 int socket_close(SocketHandle handle);
 int socket_ioctl(SocketHandle handle, uint32_t cmd, uint8_t* arg);
 
+// Blocking mode is the one socket option whose control differs per platform:
+// Winsock spells it ioctlsocket(FIONBIO), POSIX spells it fcntl(O_NONBLOCK),
+// and the two FIONBIO constants are not the same value. Callers should use
+// this rather than passing a hardcoded FIONBIO through socket_ioctl.
+int socket_set_non_blocking(SocketHandle handle, bool non_blocking);
+
 }  // namespace rex::net

--- a/src/core/socket_posix.cpp
+++ b/src/core/socket_posix.cpp
@@ -3,6 +3,7 @@
 
 static_assert(REX_PLATFORM_LINUX || REX_PLATFORM_MAC, "This file is POSIX-only");
 
+#include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
@@ -14,6 +15,16 @@ int socket_close(SocketHandle handle) {
 
 int socket_ioctl(SocketHandle handle, uint32_t cmd, uint8_t* arg) {
   return ioctl(static_cast<int>(handle), cmd, arg);
+}
+
+int socket_set_non_blocking(SocketHandle handle, bool non_blocking) {
+  const int fd = static_cast<int>(handle);
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) {
+    return -1;
+  }
+  flags = non_blocking ? (flags | O_NONBLOCK) : (flags & ~O_NONBLOCK);
+  return fcntl(fd, F_SETFL, flags);
 }
 
 }  // namespace rex::net

--- a/src/core/socket_win.cpp
+++ b/src/core/socket_win.cpp
@@ -17,4 +17,9 @@ int socket_ioctl(SocketHandle handle, uint32_t cmd, uint8_t* arg) {
   return ioctlsocket(static_cast<SOCKET>(handle), cmd, reinterpret_cast<u_long*>(arg));
 }
 
+int socket_set_non_blocking(SocketHandle handle, bool non_blocking) {
+  u_long value = non_blocking ? 1 : 0;
+  return ioctlsocket(static_cast<SOCKET>(handle), FIONBIO, &value);
+}
+
 }  // namespace rex::net

--- a/src/system/xsocket.cpp
+++ b/src/system/xsocket.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 
 #include <rex/kernel/xam/module.h>
+#include <rex/logging.h>
 #include <rex/platform.h>
 #include <rex/system/kernel_state.h>
 #include <rex/system/xsocket.h>
@@ -42,6 +43,11 @@ XSocket::~XSocket() {
   Close();
 }
 
+// FIONBIO as the guest knows it (Winsock's _IOW('f', 126, u_long)). The host
+// value differs per platform, so this is only ever compared against, never
+// passed down - see socket_set_non_blocking.
+static constexpr uint32_t kGuestFionbio = 0x8004667E;
+
 X_STATUS XSocket::Initialize(AddressFamily af, Type type, Protocol proto) {
   af_ = af;
   type_ = type;
@@ -55,6 +61,21 @@ X_STATUS XSocket::Initialize(AddressFamily af, Type type, Protocol proto) {
   native_handle_ = socket(af, type, proto);
   if (native_handle_ == -1) {
     return X_STATUS_UNSUCCESSFUL;
+  }
+
+  // Guest sockets start non-blocking.
+  //
+  // A title's main loop polls its sockets every frame and expects a read with
+  // no data waiting to come straight back as WSAEWOULDBLOCK. Left blocking,
+  // the host recvfrom() parks the guest thread until a datagram that will
+  // never arrive shows up - with no network peer, that is forever, and if the
+  // caller happens to be the guest's main thread the whole title stops.
+  // The guest can still switch the mode itself through ioctlsocket(FIONBIO).
+  if (rex::net::socket_set_non_blocking(native_handle_, true) != 0) {
+    REXLOG_WARN(
+        "XSocket: could not set socket {} non-blocking; a guest read with no data "
+        "waiting will block the calling guest thread",
+        native_handle_);
   }
 
   return X_STATUS_SUCCESS;
@@ -91,6 +112,16 @@ X_STATUS XSocket::SetOption(uint32_t level, uint32_t optname, void* optval_ptr, 
 }
 
 X_STATUS XSocket::IOControl(uint32_t cmd, uint8_t* arg_ptr) {
+  // The guest's FIONBIO is Winsock's value, which is not what a POSIX host
+  // ioctl() expects - route it through the platform helper instead of passing
+  // the guest constant straight down.
+  if (cmd == kGuestFionbio) {
+    const bool non_blocking = arg_ptr && *reinterpret_cast<uint32_t*>(arg_ptr) != 0;
+    return rex::net::socket_set_non_blocking(native_handle_, non_blocking) == 0
+               ? X_STATUS_SUCCESS
+               : X_STATUS_UNSUCCESSFUL;
+  }
+
   int ret = rex::net::socket_ioctl(native_handle_, cmd, arg_ptr);
   if (ret < 0) {
     // TODO: Get last error


### PR DESCRIPTION
## The bug

`XSocket` leaves the native socket in its default **blocking** mode, so
`XSocket::RecvFrom` calls host `recvfrom()` and parks the calling **guest**
thread until a datagram arrives. With no network peer there is no datagram, and
the wait never ends.

A title's main loop polls its sockets once per frame and expects a read with no
data waiting to return immediately as `WSAEWOULDBLOCK`. Nothing in the SDK ever
puts the socket in that mode — only the guest can, via `ioctlsocket(FIONBIO)`,
and a title that assumes the console default never calls it.

## Impact

Reproduced with Ace Combat 6 (`sal063/AC6_recomp`). The caller is the guest's
**main thread**, on the **first iteration** of its main loop:

```
sub_821D7DE0 (main loop)
  -> sub_821D7AE0 -> sub_8215ACD8 -> sub_8215C0C8 -> NetDll_recvfrom   [never returns]
```

The title presents four frames and then stops forever: black screen, working
audio (the audio callback runs on a host thread, so it is unaffected). Every
other symptom is downstream of that one blocked thread — no further `VdSwap`, no
asset streaming, an idle job dispatcher, a parked worker pool.

It is not platform specific. It reproduces on Windows with the official
prebuilt AC6 `v1.0.0-beta.1` binary, and on Linux under Proton with a
cross-compiled build.

## The fix

Set the socket non-blocking immediately after `socket()`. The guest can still
choose the mode itself through `ioctlsocket`, which now overrides this default
instead of being the only thing that ever sets it.

Blocking mode goes through a new `rex::net::socket_set_non_blocking` rather than
a hardcoded `FIONBIO`, because that constant is **not portable**:

| Platform | Mechanism | FIONBIO |
|---|---|---|
| Winsock | `ioctlsocket(FIONBIO)` | `0x8004667E` |
| Linux | `fcntl(O_NONBLOCK)` | `0x5421` |

`XSocket::IOControl` previously passed the guest's `cmd` straight to
`socket_ioctl`, which on a POSIX host means the guest's Winsock `FIONBIO` value
reaches `ioctl()` and fails. Routing it through the same helper fixes that
pre-existing mismatch too.

## Verification

Cross-compiled Windows PE (llvm-mingw / clang 22.1.8) run under GE-Proton11-5 on
RADV, and a from-scratch rebuild of the committed tree:

| | Before | After |
|---|---|---|
| `VdSwap` calls in ~40 s | 4 | 4,200+ |
| `IssueSwap: complete` | 4 | 2,118 |
| `recvfrom` returns | never | `-1` (`WSAEWOULDBLOCK`) immediately, ~100/s |
| Result | black screen | boots to the title screen and renders |

No new warnings; the non-blocking call's failure path logs and continues rather
than failing socket creation.

## Notes for review

- `socket_set_non_blocking` returns the platform return code; `Initialize` warns
  and continues on failure rather than failing the socket outright, on the
  grounds that a blocking socket is still a usable socket.
- The POSIX implementation read-modify-writes `F_GETFL` rather than assuming
  flags are otherwise zero.
- Rendering is verified as far as the title screen. Nothing beyond it has been
  tested.

## AI assistance

This change was written with AI assistance (Claude Code).

The bug was located by instrumentation rather than by reading: watchdogs around
every guest and host wait established that the title was not deadlocked, an
event census showed which sync objects were never signalled, a `VdSwap` counter
showed the guest itself had stopped presenting, and entry/exit markers injected
into the recompiled guest code narrowed the main loop down to the first call
that never returned — repeated one level deeper until the frontier was
`NetDll_recvfrom`.

Every claim in the table above is a measurement from a run of the built binary,
not an estimate. Happy to supply logs, the instrumentation, or a rerun on
request.