### PR TITLE
build: point MSPACK_DIR at the real mspack sources (fixes every Windows clone)

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -125,8 +125,11 @@ target_include_directories(aes128 PUBLIC
 target_compile_options(aes128 PRIVATE -w)
 
 # libmspack - LZX decompression (only lzxd.c needed for XEX decompression)
-# Uses cabextract version which has all needed headers in one place
-set(MSPACK_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libmspack/cabextract/mspack")
+# Use the upstream mspack sources directly. libmspack/cabextract/mspack is a
+# tree of symlinks pointing back into libmspack/libmspack/mspack; Windows git
+# defaults to core.symlinks=false, so those check out as 29-byte text stubs and
+# clang tries to compile them as C.
+set(MSPACK_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libmspack/libmspack/mspack")
 add_library(mspack STATIC
     ${MSPACK_DIR}/lzxd.c
 )


### PR DESCRIPTION
## Problem

`thirdparty/libmspack/cabextract/mspack/` is a tree of symlinks pointing into
`thirdparty/libmspack/libmspack/mspack/`.

On Windows, git uses `core.symlinks=false` by default unless the installer was
granted permission to create symbolic links. Each symlink then checks out as a
29-byte text file containing the target path.

`thirdparty/CMakeLists.txt` sets `MSPACK_DIR` to that directory, so clang tries
to compile the link text as C source:

```
lzxd.c:1:1: error: expected identifier or '('
    1 | ../../libmspack/mspack/lzxd.c
      | ^
```

The result is that **the SDK does not build on a Windows clone made with
default git settings** — which is the documented path in the README.

## Fix

Point `MSPACK_DIR` at the real upstream sources
(`libmspack/libmspack/mspack`). They are the symlink targets, so the compiled
result is identical; it just no longer depends on symlink support.

One line, no behaviour change on Linux or macOS.

## How this was found

Setting up the SDK from scratch on Windows 10 to recompile an Xbox 360 title.
Verified with a full build of the SDK and of a consuming project.