### PR TITLE
build: read the SDK version from the SDK repo, not the consumer's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,9 +186,14 @@ add_compile_definitions(REXGLUE_BUILD_CONFIG="$<CONFIG>")
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/rex_pch.cmake)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/rex_version.cmake)
+# SOURCE_DIR matters here: the default is CMAKE_SOURCE_DIR, which points at the
+# *consumer's* top-level source directory whenever the SDK is pulled in with
+# add_subdirectory. git describe then runs in the wrong repository and a release
+# tag in the consuming project is compared against the SDK's version floor.
 rex_resolve_version(REXGLUE_FULL_VERSION
     FLOOR_MAJOR ${PROJECT_VERSION_MAJOR}
-    FLOOR_MINOR ${PROJECT_VERSION_MINOR})
+    FLOOR_MINOR ${PROJECT_VERSION_MINOR}
+    SOURCE_DIR  ${REXGLUE_ROOT})
 
 # Strip the -id trailer (if any) for the numeric-only version.
 string(REGEX REPLACE "-.*$" "" REXGLUE_NUMERIC_VERSION "${REXGLUE_FULL_VERSION}")


### PR DESCRIPTION
## Problem

`rex_resolve_version` defaults `SOURCE_DIR` to `CMAKE_SOURCE_DIR`:

```cmake
if(NOT ARG_SOURCE_DIR)
    set(ARG_SOURCE_DIR "${CMAKE_SOURCE_DIR}")
endif()
```

`CMAKE_SOURCE_DIR` is the **top-level** project — the consumer, whenever the SDK
is pulled in with `add_subdirectory`, which is the documented source-tree
workflow. `git describe` therefore runs in the consuming repository, and a
release tag there gets compared against the SDK's own version floor.

Tagging `v1.0.0` in a project that consumes the SDK is enough to abort
configure:

```
CMake Error at cmake/rex_version.cmake:64 (message):
  rex_compute_version: floor version (0.10) is behind tag version (1.0).
  The floor in CMakeLists.txt must not regress.
```

The SDK checkout itself was clean and describes correctly as
`v0.8.0-103-gc94f5eb`. Nothing about the SDK had changed — the consuming
project had simply cut a release.

## Fix

Pass `SOURCE_DIR` explicitly at the call site. `REXGLUE_ROOT` is already set to
`CMAKE_CURRENT_SOURCE_DIR` a few lines above for exactly this kind of use.

After the change, configure reports the SDK's real version again:

```
--   Version: 0.10.0-dev.gc94f5eb (dev)
```

## Reproducing

1. Consume the SDK from source via `add_subdirectory`.
2. `git tag v1.0.0` in the consuming project.
3. Configure — it aborts.

## How this was found

Publishing the first release of a project built on the SDK. The tag broke a
build that had been working all day, and the error pointed at the SDK rather
than at the change that caused it, which is what makes this one worth fixing:
the failure surfaces far from its cause.