### PR TITLE
codegen: optional REX_DUMP_IMAGE to dump the decompressed guest image

### DIFF
--- a/src/codegen/project_recompiler.cpp
+++ b/src/codegen/project_recompiler.cpp
@@ -13,7 +13,10 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <span>
+#include <cstring>
+#include <cstdlib>
 #include <unordered_map>
 
 #include <fmt/format.h>
@@ -308,6 +311,23 @@ Result<void> ProjectRecompiler::Run(const ProjectRecompilerOptions& opts) {
   {
     auto execMod = runtime->kernel_state()->GetExecutableModule();
     auto bv = BinaryView::fromModule(*execMod->xex_module());
+
+    // Optional: dump the decompressed/decrypted guest image for external analysis
+    // (e.g. the jump-table IDA pass). Off unless REX_DUMP_IMAGE names an output path.
+    // Reconstruct a contiguous image: each section copied to (sec base - image base);
+    // gaps (PE headers, inter-section padding) stay zero, matching guest layout.
+    if (const char* dumpPath = std::getenv("REX_DUMP_IMAGE")) {
+      std::vector<uint8_t> img(bv.imageSize(), 0);
+      for (const auto& sec : bv.sections()) {
+        uint32_t off = sec.baseAddress - bv.baseAddress();
+        if (sec.data && off <= img.size() && off + sec.size <= img.size())
+          std::memcpy(img.data() + off, sec.data, sec.size);
+      }
+      std::ofstream ofs(dumpPath, std::ios::binary);
+      ofs.write(reinterpret_cast<const char*>(img.data()), img.size());
+      REXCODEGEN_INFO("Dumped guest image to {} ({:#x} bytes, base {:#010x}, {} sections)",
+                      dumpPath, bv.imageSize(), bv.baseAddress(), bv.sections().size());
+    }
 
     auto entry_display = make_display_name(targeted[0].config.filePath);
     RecompilerConfig cfg = std::move(targeted[0].config);


### PR DESCRIPTION
Static analysis that runs *outside* rexglue needs the decrypted, decompressed
guest image as a flat file:

- jump-table recovery in IDA,
- scanning the data sections for function pointers a control-flow scan cannot see,
- mapping which parts of the code range codegen actually covered.

There is currently no way to obtain one. rexglue has the image in memory and
discards it; the alternatives are re-implementing XEX decryption + LZX
decompression, or reading it back out of a running port.

**What this adds.** When `REX_DUMP_IMAGE` names a path, `ProjectRecompiler::Run`
writes the image it already holds: a zero-filled buffer of `bv.imageSize()` with
each section copied to `section.baseAddress - bv.baseAddress()`, so gaps (PE
headers, inter-section padding) stay zero and file offsets are guest offsets.

```
REX_DUMP_IMAGE=game.bin rexglue codegen project.toml
```

**Cost.** 20 lines in one file, no new dependency, and nothing runs unless the
variable is set -- with it unset the generated output is byte-identical.

We have carried this in a fork for a while and it seemed better offered upstream
than kept. Happy to adjust the name, move it behind a CLI flag instead of an
environment variable, or gate it on a build option if you would prefer any of
those.
