### PR TITLE
kernel/xam: own the content root name across the deferred completion

### DIFF
--- a/src/kernel/xam/xam_content.cpp
+++ b/src/kernel/xam/xam_content.cpp
@@ -9,6 +9,7 @@
  * @modified    Tom Clay, 2026 - Adapted for ReXGlue runtime
  */
 
+#include <string>
 #include <rex/cvar.h>
 #include <rex/kernel/xam/private.h>
 #include <rex/logging.h>
@@ -141,8 +142,15 @@ u32 xeXamContentCreate(u32 user_index, mapped_string root_name, mapped_void cont
     *disposition_ptr = 0;
   }
 
-  auto run = [content_manager, xuid, root_name = root_name.value(), flags, content_data,
-              disposition_ptr,
+  // root_name.value() is a std::string_view over GUEST memory. This lambda is
+  // handed to CompleteOverlappedDeferredEx and runs later on the dispatch
+  // thread, by which point the title has typically reused that buffer -- the
+  // view then reads whatever is there now. Gears of War Judgment hit this
+  // ~13s in: the stale bytes reached string_key_case::hash() -> utf8 iteration,
+  // which threw utf8::invalid_utf8 out of the deferred call and tripped
+  // REX_FATAL. Own the bytes so the deferred run sees the name it was given.
+  auto run = [content_manager, xuid, root_name = std::string(root_name.value()), flags,
+              content_data, disposition_ptr,
               license_mask_ptr](uint32_t& extended_error, uint32_t& length) -> X_RESULT {
     X_RESULT result = X_ERROR_INVALID_PARAMETER;
     kDispositionState disposition = kDispositionState::Unknown;


### PR DESCRIPTION
`xeXamContentCreate` captures `root_name = root_name.value()` into the lambda it
hands to `CompleteOverlappedDeferredEx`. `MappedPtr<char>::value()` returns a
`std::string_view` over **guest** memory, and the lambda does not run until the
dispatch thread drains the queue — by which point the title has typically reused
that buffer. The deferred run then reads whatever is there now.

### Reproduction

Gears of War Judgment hits it in ~13 s, three runs out of three. The stale bytes
(`40 00 07 80 82 9D 5F A8 65 30` — note the embedded guest pointer) reach
`content_manager`'s `open_packages_` lookup, so `string_key_case::hash()` →
`utf8_hash_fnv1a_case()` iterates them as UTF-8 and utfcpp throws
`utf8::invalid_utf8`. The exception escapes the deferred call and the dispatch
thread's catch turns it into

```
[FATAL] Dispatch thread: deferred completion threw 'Invalid UTF-8'
```

which fastfails the process (`STATUS_STACK_BUFFER_OVERRUN`, `0xC0000409`). With
the fix the same build runs 108 s with zero fatals.

### Why it is title-dependent

The synchronous path is unaffected: when `overlapped_ptr` is null the lambda runs
inline and the view is still live. Only the async path dangles — which is why a
title that never passes an overlapped (Dante's Inferno makes no `XamContent` call
at all) never sees it.

Copying the name is enough; it is a handful of bytes, once per content open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
