### PR TITLE
codegen: dispatch instead of trapping on an out-of-range jump-table index

### DIFF
--- a/src/codegen/builders/control_flow.cpp
+++ b/src/codegen/builders/control_flow.cpp
@@ -168,7 +168,17 @@ bool build_bctr(BuilderContext& ctx) {
     }
 
     ctx.println("\tdefault:");
-    ctx.println("\t\t__builtin_trap(); // Switch case out of range");
+    // A recovered jump table is a best-effort reconstruction, not a proof of the
+    // index's full range: the game can legitimately reach an index the table
+    // does not cover. __builtin_trap() lowers to `ud2`, so that case killed the
+    // process with STATUS_ILLEGAL_INSTRUCTION and nothing in the log -- Gears of
+    // War Judgment died ~5s in, at one of 121 such defaults, while the same
+    // title runs for minutes when the default dispatches instead. Fall back to
+    // the same indirect dispatch used when no table was recovered at all; the
+    // runtime already reports an unresolved target there, so a genuinely bad
+    // index is still diagnosed, just not with an illegal instruction.
+    ctx.println("\t\tREX_CALL_INDIRECT_FUNC({}.u32);", ctx.ctr());
+    ctx.println("\t\treturn;");
     ctx.println("\t}}");
 
     ctx.reset_switch_table();


### PR DESCRIPTION
A recovered jump table lowers to a switch on the index register, and its
`default:` arm emits `__builtin_trap()`. A recovered table is a best-effort
reconstruction, not a proof of the index's full range, so reaching the default is
not by itself a bug — but `__builtin_trap()` lowers to `ud2`, so it kills the
process with `STATUS_ILLEGAL_INSTRUCTION` and nothing in the log.

Gears of War Judgment died ~5 s in at one of its **121** such defaults. The same
title runs for minutes when the default dispatches instead.

### Why dispatching is well defined here

The emitted body always assigns `ctx.ctr` from the table load before the `bctr`:

```
// lwzx r0,r12,r0
ctx.r0.u64 = REX_LOAD_U32(ctx.r12.u32 + ctx.r0.u32);
// mtctr r0
ctx.ctr.u64 = ctx.r0.u64;
// bctr
switch (ctx.r11.u32) { ... }
```

so `ctr` holds the address the hardware would have jumped to. This is also what
0.8.2 emitted — it switched on `ctr` with address cases and defaulted to
`REX_CALL_INDIRECT_FUNC(ctr)` — and what this same function already emits when no
table is recovered at all. A genuinely bad index is still diagnosed, by the
runtime's unresolved-target report, rather than by an illegal instruction.

### No hot-path cost

Compiling a representative switch both ways with clang at `-O2` gives a
byte-identical dispatch prologue — same bounds check (`cmp rax, N` / `ja`), same
jump table, same `jmp rax`. The only difference is the cold out-of-range block:
`ud2` (1 instruction) versus a two-instruction tail call; 56 vs 57 instructions
in the whole function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
