### PR TITLE
codegen: [[image_patch]] — byte patches applied to the image before analysis

### DIFF
--- a/include/rex/codegen/config.h
+++ b/include/rex/codegen/config.h
@@ -25,6 +25,16 @@
 
 namespace rex::codegen {
 
+struct ImagePatch {
+  std::string name;      // for logging; from the community patch entry
+  uint32_t address = 0;  // guest virtual address
+  std::vector<uint8_t> data;
+  // Bytes the patch author saw at `address`. Recorded when the patch is
+  // converted so a game dump of a different build is refused instead of
+  // silently corrupted. Empty means "apply unchecked".
+  std::vector<uint8_t> expect;
+};
+
 struct MidAsmHook {
   std::string name;
   std::vector<std::string> registers;
@@ -111,6 +121,13 @@ struct RecompilerConfig {
   std::unordered_map<uint32_t, FunctionConfig> functions;  ///< Function/chunk configuration
   std::unordered_map<uint32_t, JumpTable> switchTables;
   std::unordered_map<uint32_t, MidAsmHook> midAsmHooks;
+
+  // Byte patches applied to the decoded guest image before analysis. A static
+  // recompiler translates guest instructions ahead of time, so a code patch has
+  // to land here -- poking guest memory at runtime would not change the native
+  // code that was already generated. This is what makes the community patch
+  // databases (xenia-canary/game-patches and friends) usable in a port.
+  std::vector<ImagePatch> imagePatches;
   uint32_t longJmpAddress = 0;
   uint32_t setJmpAddress = 0;
 

--- a/src/codegen/config.cpp
+++ b/src/codegen/config.cpp
@@ -307,6 +307,73 @@ void ApplyToml(const toml::table& toml, RecompilerConfig& cfg, const std::string
     }
   }
 
+  // [[image_patch]] -- byte patches applied to the decoded image before analysis.
+  // Additive across included files so a community patch set can live in its own
+  // TOML alongside the discovered cures.
+  if (auto imagePatchArray = toml["image_patch"].as_array()) {
+    for (auto& entry : *imagePatchArray) {
+      auto* table = entry.as_table();
+      if (!table) {
+        REXCODEGEN_ERROR("Invalid [[image_patch]] entry: expected table");
+        continue;
+      }
+      auto address_opt = (*table)["address"].value<uint32_t>();
+      auto data_opt = (*table)["data"].value<std::string>();
+      if (!address_opt) {
+        REXCODEGEN_ERROR("Missing 'address' in [[image_patch]] entry");
+        continue;
+      }
+      if (!data_opt || data_opt->empty() || data_opt->size() % 2 != 0) {
+        REXCODEGEN_ERROR(
+            "[[image_patch]] 0x{:08X}: 'data' must be a non-empty even-length hex "
+            "string of the bytes as they appear in the image",
+            *address_opt);
+        continue;
+      }
+      auto decodeHex = [](std::string_view in, std::vector<uint8_t>& out) -> bool {
+        auto hexval = [](char c) -> int {
+          if (c >= '0' && c <= '9')
+            return c - '0';
+          if (c >= 'a' && c <= 'f')
+            return c - 'a' + 10;
+          if (c >= 'A' && c <= 'F')
+            return c - 'A' + 10;
+          return -1;
+        };
+        for (size_t i = 0; i + 1 < in.size(); i += 2) {
+          int hi = hexval(in[i]), lo = hexval(in[i + 1]);
+          if (hi < 0 || lo < 0)
+            return false;
+          out.push_back(static_cast<uint8_t>((hi << 4) | lo));
+        }
+        return true;
+      };
+
+      ImagePatch patch;
+      patch.address = *address_opt;
+      patch.name = (*table)["name"].value_or(std::string{});
+      if (!decodeHex(*data_opt, patch.data)) {
+        REXCODEGEN_ERROR("[[image_patch]] 0x{:08X}: 'data' is not valid hex", *address_opt);
+        continue;
+      }
+      if (auto expect_opt = (*table)["expect"].value<std::string>()) {
+        if (expect_opt->size() % 2 != 0 || !decodeHex(*expect_opt, patch.expect)) {
+          REXCODEGEN_ERROR("[[image_patch]] 0x{:08X}: 'expect' is not an even-length hex string",
+                           *address_opt);
+          continue;
+        }
+        if (patch.expect.size() != patch.data.size()) {
+          REXCODEGEN_ERROR("[[image_patch]] 0x{:08X}: 'expect' is {} byte(s) but 'data' is {}",
+                           *address_opt, patch.expect.size(), patch.data.size());
+          continue;
+        }
+      }
+      REXCODEGEN_DEBUG("[config]   [[image_patch]] 0x{:08X} +{} byte(s) \"{}\" from {}",
+                       patch.address, patch.data.size(), patch.name, filePath);
+      cfg.imagePatches.push_back(std::move(patch));
+    }
+  }
+
   // [[midasm_hook]] -- keyed by "address"
   if (auto midAsmHookArray = toml["midasm_hook"].as_array()) {
     for (auto& entry : *midAsmHookArray) {

--- a/src/codegen/project_recompiler.cpp
+++ b/src/codegen/project_recompiler.cpp
@@ -311,6 +311,50 @@ Result<void> ProjectRecompiler::Run(const ProjectRecompilerOptions& opts) {
 
     auto entry_display = make_display_name(targeted[0].config.filePath);
     RecompilerConfig cfg = std::move(targeted[0].config);
+
+    // Apply [[image_patch]] entries to the decoded image before any analysis
+    // runs. These have to land here rather than at runtime: the recompiler
+    // translates guest instructions ahead of time, so a patched opcode only
+    // takes effect if it is patched before it is read. SectionView::data is
+    // const because analysis never writes; the storage behind it is the loaded
+    // module's own writable image, which is what we mean to edit.
+    for (const auto& patch : cfg.imagePatches) {
+      const SectionView* target = nullptr;
+      for (const auto& sec : bv.sections()) {
+        if (sec.data && sec.contains(patch.address) &&
+            patch.address + patch.data.size() <= sec.end()) {
+          target = &sec;
+          break;
+        }
+      }
+      if (!target) {
+        REXCODEGEN_ERROR(
+            "[[image_patch]] 0x{:08X} \"{}\": address is outside every section, or "
+            "the patch runs past the end of one; skipped",
+            patch.address, patch.name);
+        continue;
+      }
+      auto* dst = const_cast<uint8_t*>(target->translate(patch.address));
+      if (!patch.expect.empty() &&
+          std::memcmp(dst, patch.expect.data(), patch.expect.size()) != 0) {
+        auto hex = [](const uint8_t* p, size_t n) {
+          std::string out;
+          for (size_t i = 0; i < n; i++)
+            out += fmt::format("{:02X}", p[i]);
+          return out;
+        };
+        REXCODEGEN_ERROR(
+            "[[image_patch]] 0x{:08X} \"{}\": image holds {} but the patch was written against "
+            "{}. This game dump is a different build -- skipping rather than corrupting it.",
+            patch.address, patch.name, hex(dst, patch.expect.size()),
+            hex(patch.expect.data(), patch.expect.size()));
+        continue;
+      }
+      std::memcpy(dst, patch.data.data(), patch.data.size());
+      REXCODEGEN_INFO("Applied image patch 0x{:08X} +{} byte(s) in {}{}{}", patch.address,
+                      patch.data.size(), target->name, patch.name.empty() ? "" : " -- ",
+                      patch.name);
+    }
     if (opts.enableExceptionHandlers)
       cfg.generateExceptionHandlers = true;
 


### PR DESCRIPTION
Adds an optional `[[image_patch]]` block to the codegen config:

```toml
[[image_patch]]
name    = "Unlock FPS"
address = 0x8255DE08
data    = "60000000"
expect  = "C02304CC"
```

Entries are applied to the decoded guest image immediately after it is loaded and
before any analysis runs.

### Why it has to be there rather than at runtime

This is a static recompiler. A guest instruction is translated once, ahead of
time, and the native code never reads guest memory for it again — so a code patch
only takes effect if the image carries it before codegen. That single property is
what makes the community patch databases (`xenia-canary/game-patches` and
friends, thousands of entries keyed by title ID) usable in a port at all: they are
lists of byte writes, and most of them land in `.text`.

### The `expect` guard

`expect` is optional and records the bytes the patch author saw at that address. A
mismatch refuses the patch with a diagnostic instead of applying it. Without it,
running the same patch set against a different build of the same title silently
overwrites an unrelated instruction — a miscompile with no symptom at the point of
the mistake. (Two builds really do differ: on Judgment "Unlock FPS" is
`0x8255DE08` on the base game and `0x8255E220` on TU4.)

Verified by deliberately corrupting an `expect` value: the patch is skipped, the
original instruction survives in the generated code, and the reason is reported.

### Measured

Gears of War Judgment with the community "Unlock FPS" entry: the
`lfs f1,1228(r3)` at `0x8255DE08` comes out as `nop` in the generated C++, the
title's 30 fps cap is gone, and recompilation is unchanged — 99.2073% of code
bytes, 60,146 functions, 0 holes, identical to the unpatched build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
