### PR TITLE
input: guard the device tables against concurrent guest polls

### DIFF
--- a/include/rex/input/input_system.h
+++ b/include/rex/input/input_system.h
@@ -11,6 +11,7 @@
  */
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include <rex/input/device_assignment.h>
@@ -63,6 +64,18 @@ class InputSystem : public system::IInputSystem {
 
   // Ordered by ordinal. Ordinals are never recycled, so unplugging pad one
   // does not renumber pad two.
+  // Guards every mutable field below, and the assignment_ / active_devices_
+  // state the public entry points walk. RefreshDevices() clears and rebuilds
+  // devices_ and device_owners_, and it runs on EVERY XamInputGetState --
+  // which titles call from more than one guest thread at once. Two concurrent
+  // polls were freeing and reallocating the same std::vector, which is how
+  // Gears of War Judgment died between 48s and 160s with a heap corruption
+  // (0xC0000374) or a use-after-free (0xC0000005) and nothing in the log.
+  //
+  // Recursive because RefreshDevices() is public API: it locks on its own, and
+  // the entry points that already hold the lock call it too.
+  mutable std::recursive_mutex devices_mutex_;
+
   std::vector<DeviceInfo> devices_;
   std::vector<InputDriver*> device_owners_;
 };

--- a/src/input/input_system.cpp
+++ b/src/input/input_system.cpp
@@ -72,6 +72,7 @@ void InputSystem::SetActiveCallback(std::function<bool()> callback) {
 }
 
 void InputSystem::SetDeviceAssignment(std::unique_ptr<DeviceAssignment> assignment) {
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   assignment_ = std::move(assignment);
   if (assignment_) {
     assignment_->OnDevicesChanged(devices_);
@@ -79,6 +80,7 @@ void InputSystem::SetDeviceAssignment(std::unique_ptr<DeviceAssignment> assignme
 }
 
 void InputSystem::RefreshDevices() {
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   std::vector<DeviceInfo> seen;
   std::vector<InputDriver*> owners;
   std::vector<DeviceInfo> enumerated;
@@ -167,6 +169,7 @@ void InputSystem::RefreshDevices() {
 }
 
 InputDriver* InputSystem::DriverForDevice(DeviceId id) {
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   for (size_t i = 0; i < devices_.size(); i++) {
     if (devices_[i].id == id) {
       return device_owners_[i];
@@ -176,6 +179,7 @@ InputDriver* InputSystem::DriverForDevice(DeviceId id) {
 }
 
 const DeviceInfo* InputSystem::DeviceInfoFor(DeviceId id) const {
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   for (const auto& device : devices_) {
     if (device.id == id) {
       return &device;
@@ -187,6 +191,7 @@ const DeviceInfo* InputSystem::DeviceInfoFor(DeviceId id) const {
 X_RESULT InputSystem::GetCapabilities(uint32_t user_index, uint32_t flags,
                                       X_INPUT_CAPABILITIES* out_caps) {
   SCOPE_profile_cpu_f("hid");
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   if (!out_caps || !assignment_) {
     return X_ERROR_DEVICE_NOT_CONNECTED;
   }
@@ -214,6 +219,7 @@ X_RESULT InputSystem::GetCapabilities(uint32_t user_index, uint32_t flags,
 
 X_RESULT InputSystem::GetState(uint32_t user_index, X_INPUT_STATE* out_state) {
   SCOPE_profile_cpu_f("hid");
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   if (!assignment_) {
     return X_ERROR_DEVICE_NOT_CONNECTED;
   }
@@ -253,6 +259,7 @@ X_RESULT InputSystem::GetState(uint32_t user_index, X_INPUT_STATE* out_state) {
 
 X_RESULT InputSystem::SetState(uint32_t user_index, X_INPUT_VIBRATION* vibration) {
   SCOPE_profile_cpu_f("hid");
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   if (!assignment_) {
     return X_ERROR_DEVICE_NOT_CONNECTED;
   }
@@ -295,6 +302,7 @@ X_RESULT InputSystem::SetState(uint32_t user_index, X_INPUT_VIBRATION* vibration
 X_RESULT InputSystem::GetKeystroke(uint32_t user_index, uint32_t flags,
                                    X_INPUT_KEYSTROKE* out_keystroke) {
   SCOPE_profile_cpu_f("hid");
+  std::lock_guard<std::recursive_mutex> lock(devices_mutex_);
   if (!assignment_) {
     return X_ERROR_DEVICE_NOT_CONNECTED;
   }


### PR DESCRIPTION
`InputSystem` has no synchronisation at all, and `RefreshDevices()` clears and
rebuilds `devices_` and `device_owners_` on **every** call. It is called from all
four guest-facing entry points -- `GetCapabilities`, `GetState`, `SetState`,
`GetKeystroke` -- which titles reach through `XamInput*` from more than one guest
thread at a time. Two concurrent polls therefore free and reallocate the same
`std::vector`.

### Reproduction

Gears of War Judgment dies from this between roughly 48s and 160s of gameplay,
either as `STATUS_HEAP_CORRUPTION` (0xC0000374) or as an access violation inside
the allocator, with **nothing in the log** -- both are fail-fast paths, so neither
a vectored handler nor an unhandled-exception filter sees them. Symbolised, the
faulting stack is:

```
guest sub_82DCA948 -> sub_8232D958 -> sub_8299CAE0
  XamInputGetState_entry            xam_input.cpp:115
  InputSystem::RefreshDevices()     input_system.cpp:157
  std::vector<DeviceInfo>::clear() -> _Destroy_range -> deallocate   <-- faults
```

It only shows up once a title is actually rendering and polling input: with no
GPU plugin loaded the same build exits cleanly at 27s and never reaches the loop.

### Scope of the lock

The lock covers the whole body of each entry point, not just `RefreshDevices()`.
`assignment_` (rebuilt by `OnDevicesChanged`, read by `DevicesForUser`) and
`active_devices_` are the same shared state reached from the same threads, so
guarding the vectors alone would only move the race.

`std::recursive_mutex` because `RefreshDevices()` is public API: it takes the
lock itself, and the entry points that already hold it call it too.

### Measured

Same build, same title, D3D12 debug layer on to make it fail sooner.

| | result |
|---|---|
| before | died at 13s / 54s / 74s / 121s / 160s |
| after | three runs of 200s, zero fatals, no crash report |

Worth noting separately: `RefreshDevices()` re-enumerating every driver on every
input poll is a lot of work per frame. This PR only fixes the correctness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
