### PR TITLE
cli: report an exception that escapes a command instead of dying with it

### DIFF
--- a/src/rexglue/main.cpp
+++ b/src/rexglue/main.cpp
@@ -105,7 +105,22 @@ int main(int argc, char** argv) {
   rexglue::ui::Banner(TitleString());
 
   auto start = std::chrono::steady_clock::now();
-  rex::Result<void> result = pending ? pending() : rex::Ok();
+  // A command reports failure through Result, but anything it THROWS escaped
+  // this frame: no handler, no summary, the process dies as 0xE06D7363 and the
+  // message the thrower took care to build is never seen. FunctionGraph::sealAll
+  // is one such -- "N functions cannot be sealed: <which, and why>" -- and it
+  // took a symbolised crash dump to learn that from a Forza Horizon codegen that
+  // just vanished after the Write banner. Report it like any other failure.
+  rex::Result<void> result = rex::Ok();
+  try {
+    if (pending) {
+      result = pending();
+    }
+  } catch (const std::exception& e) {
+    result = rex::Err(rex::ErrorCategory::Runtime, e.what());
+  } catch (...) {
+    result = rex::Err(rex::ErrorCategory::Runtime, "unhandled non-std exception");
+  }
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start);
 


### PR DESCRIPTION
A command reports failure through `Result`, but anything it **throws** escapes `main()`: no handler, no summary, the process exits `0xE06D7363` and the message the thrower built is never seen.

Two real throwers hit this on Forza Horizon:

- `FunctionGraph::sealAll` -- its message names every function that cannot be sealed and why (`still in kRegistered`, `0 blocks`, `N unresolved jumps`). All of that died with the process.
- `std::bad_alloc` -- the codegen vanished after the `Write` banner four times in six minutes on a machine whose commit limit a game running in the background had exhausted. The system's Resource-Exhaustion-Detector events were the only clue; with this change the failure summary says `bad allocation`.

Catch at the top of `main()` and route it through the existing `FailureSummary`, exit code 1, same as any other failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
