### PR TITLE
codegen: a jump-table landing inside the function being emitted is a goto, not a REX_FATAL

### DIFF
--- a/src/codegen/builders/control_flow.cpp
+++ b/src/codegen/builders/control_flow.cpp
@@ -160,6 +160,21 @@ bool build_bctr(BuilderContext& ctx) {
           ctx.println("\t\treturn;");
           break;
         default:
+          // classifyTarget asks the graph which node CONTAINS the bctr, and that
+          // is not always the function being emitted. A routine with an embedded
+          // jump table gets split at the table's data, so the node containing the
+          // bctr can end right there while the emit walk -- driven by control flow
+          // from the real entry -- carries on well past it. Forza Horizon's
+          // sub_82FFFC38 emits `bctr 0x82FFFE28`, the graph hands back a node that
+          // stops at the table data at 0x82FFFE2C, and all five landings
+          // (0x82FFFE5C..0x82FFFE7C) came back Unknown -- even though they sit
+          // inside the function being emitted and DO get their `loc_` labels a few
+          // lines below. The REX_FATAL then killed the game at the first dispatch.
+          // Ask the function we are actually emitting before giving up.
+          if (label >= ctx.fn.base() && label < ctx.fn.end()) {
+            ctx.println("\t\tgoto loc_{:X};", label);
+            break;
+          }
           REXCODEGEN_ERROR("Jump target 0x{:08X} unresolved at bctr 0x{:08X}", label, ctx.base);
           ctx.println("\t\tREX_FATAL(\"Jump target 0x{:08X} unresolved at bctr 0x{:08X}\");", label,
                       ctx.base);


### PR DESCRIPTION
`classifyTarget` asks the graph which node *contains* the bctr, and that is
not always the function being emitted. A routine with an embedded jump table is
split at the table's data, so the containing node can end right there while the
emit walk — driven by control flow from the real entry — carries on past it.

Forza Horizon's `sub_82FFFC38` emits `bctr 0x82FFFE28`; the graph hands back a
node that stops at the table data at `0x82FFFE2C`, and all five landings
(`0x82FFFE5C..0x82FFFE7C`) came back `Unknown` — even though they sit inside the
function being emitted and get their `loc_` labels a few lines below. The
`REX_FATAL` killed the game at the first dispatch.

**Measured:** Forza Horizon 12 `REX_FATAL` cases → 0, with no config change.
Dante's Inferno carried 15 of the same shape in `sub_82907D90` (label present,
same function).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
