### PR TITLE
codegen: warn when a config override lands on a save/restore helper

### DIFF
--- a/src/codegen/function_graph.cpp
+++ b/src/codegen/function_graph.cpp
@@ -749,6 +749,17 @@ FunctionNode* FunctionGraph::addFunction(uint32_t base, uint32_t size, FunctionA
     }
 
     // Replace with higher authority
+    if (existing->authority() == FunctionAuthority::HELPER) {
+      // A config entry sitting on a save/restore helper turns every bl/b into
+      // it from the intrinsic into a real call, and gap-fill tooling produces
+      // exactly such entries because the helper tables have no C++ behind them.
+      // Forza Horizon booted to a null read that way. Nobody writes this on
+      // purpose, so say it where a default log level shows it.
+      REXCODEGEN_WARN(
+          "FunctionGraph: config overrides the {} helper at 0x{:08X}; its callers lose the "
+          "intrinsic -- almost certainly a stray function override",
+          existing->name(), base);
+    }
     REXCODEGEN_DEBUG("FunctionGraph: replacing 0x{:08X} ({}) with ({})", base,
                      AuthorityName(existing->authority()), AuthorityName(authority));
   }


### PR DESCRIPTION
A config entry sitting on a save/restore helper turns every `bl`/`b` into it
from the intrinsic into a real call, and gap-fill tooling produces exactly such
entries because the helper tables have no C++ behind them.

Forza Horizon had all eight heads (`__savegprlr_14` … `__restvmx_64`) registered
that way; 472 + 669 call sites became calls of an emitted `sub_82A7DDD0` /
`sub_82A7DE20` and the game booted to a null read in a routine whose instructions
were otherwise byte-identical to a build that reached gameplay.

Nobody writes this on purpose, and the only trace was a `DEBUG` line, so say it
at a level a default build shows.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
